### PR TITLE
Undo code owner teams

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @etn-ccis/brightlayer-ui
+* @surajeaton @daileytj @JeffGreiner-eaton


### PR DESCRIPTION
No longer listing BLUI as a team codeowner, as this will withdraw the code review from other team members as soon as someone makes a comment