### PR TITLE
Blui 3927 resend verification code

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 -   Confirm password field error state message in `ChangePasswordForm`.
 
+### Changed
+
+-   Changed the verification code styles for the self registration workflow.
+
 ## v3.1.1 (December 14, 2022)
 
 ### Changed

--- a/login-workflow/example/cypress/e2e/self-reg-chinese.cy.ts
+++ b/login-workflow/example/cypress/e2e/self-reg-chinese.cy.ts
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 /// <reference types="cypress-localstorage-commands" />
 
-describe('Language spanish', () => {
+describe('Language chinese', () => {
     beforeEach(() => {
         cy.visit('http://localhost:3000/custom-login-route');
     });
@@ -20,7 +20,7 @@ describe('Language spanish', () => {
         cy.contains('验证邮箱');
         cy.get('#code-label').should('contain', '验证码');
         cy.get('#code').click().type('123');
-        cy.contains('重新发送验证邮件').should('be.enabled').click();
+        cy.contains('重新发送').click();
         cy.contains('下一步').should('be.enabled').click();
         cy.contains('创建密码');
         cy.get('#password').click().type('Test321!');

--- a/login-workflow/example/cypress/e2e/self-reg-english.cy.ts
+++ b/login-workflow/example/cypress/e2e/self-reg-english.cy.ts
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 /// <reference types="cypress-localstorage-commands" />
 
-describe('Language spanish', () => {
+describe('Language english', () => {
     beforeEach(() => {
         cy.visit('http://localhost:3000/custom-login-route');
     });
@@ -20,7 +20,7 @@ describe('Language spanish', () => {
         cy.contains('Verify Email');
         cy.get('#code-label').should('contain', 'Verification Code');
         cy.get('#code').click().type('123');
-        cy.contains('Resend Verification Email').should('be.enabled').click();
+        cy.contains('Send Again').click();
         cy.contains('Next').should('be.enabled').click();
         cy.contains('Create Password');
         cy.get('#password').click().type('Test321!');

--- a/login-workflow/example/cypress/e2e/self-reg-french.cy.ts
+++ b/login-workflow/example/cypress/e2e/self-reg-french.cy.ts
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 /// <reference types="cypress-localstorage-commands" />
 
-describe('Language spanish', () => {
+describe('Language french', () => {
     beforeEach(() => {
         cy.visit('http://localhost:3000/custom-login-route');
     });
@@ -20,7 +20,7 @@ describe('Language spanish', () => {
         cy.contains('Vérifier les courriels');
         cy.get('#code-label').should('contain', 'Code de vérification');
         cy.get('#code').click().type('123');
-        cy.contains('Renvoyer').should('be.enabled').click();
+        cy.contains('Envoyer à nouveau').click();
         cy.contains('Prochain').should('be.enabled').click();
         cy.contains('Créer un Mot de Passe');
         cy.get('#password').click().type('Test321!');

--- a/login-workflow/example/cypress/e2e/self-reg-portuguese.cy.ts
+++ b/login-workflow/example/cypress/e2e/self-reg-portuguese.cy.ts
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 /// <reference types="cypress-localstorage-commands" />
 
-describe('Language spanish', () => {
+describe('Language portuguese', () => {
     beforeEach(() => {
         cy.visit('http://localhost:3000/custom-login-route');
     });
@@ -20,7 +20,7 @@ describe('Language spanish', () => {
         cy.contains('Verificar E-mail');
         cy.get('#code-label').should('contain', 'Código de verificação');
         cy.get('#code').click().type('123');
-        cy.contains('Reenviar e-mail').should('be.enabled').click();
+        cy.contains('Envie novamente').click();
         cy.contains('Próximo').should('be.enabled').click();
         cy.contains('Criar palavra-passe');
         cy.get('#password').click().type('Test321!');

--- a/login-workflow/example/cypress/e2e/self-reg-spanish.cy.ts
+++ b/login-workflow/example/cypress/e2e/self-reg-spanish.cy.ts
@@ -22,7 +22,7 @@ describe('Language spanish', () => {
         cy.contains('Verificar correo electrónico');
         cy.get('#code-label').should('contain', 'Código de verificación');
         cy.get('#code').click().type('123');
-        cy.contains('Reenviar correo electrónico de verificación').should('be.enabled').click();
+        cy.contains('Enviar de nuevo').click();
         cy.contains('Siguiente').should('be.enabled').click();
         cy.contains('Crear contraseña');
         cy.get('#password').click().type('Test321!');

--- a/login-workflow/src/screens/subScreens/VerifyEmail.tsx
+++ b/login-workflow/src/screens/subScreens/VerifyEmail.tsx
@@ -62,9 +62,10 @@ export const VerifyEmail: React.FC<React.PropsWithChildren<React.PropsWithChildr
                     {t('blui:SELF_REGISTRATION.VERIFY_EMAIL.VERIFICATION_CODE_PROMPT')}
                 </Typography>
                 <Typography
-                    sx={{ display: 'inline', '&:hover': { cursor: 'pointer' } }}
+                    sx={{ display: 'inline', textTransform: 'initial', '&:hover': { cursor: 'pointer' } }}
                     onClick={(): void => onResendVerificationEmail()}
                     color="primary"
+                    variant={'button'}
                 >
                     &nbsp;<u>{t('blui:ACTIONS.RESEND')}</u>
                 </Typography>

--- a/login-workflow/src/screens/subScreens/VerifyEmail.tsx
+++ b/login-workflow/src/screens/subScreens/VerifyEmail.tsx
@@ -5,7 +5,7 @@ import TextField from '@mui/material/TextField';
 import Divider from '@mui/material/Divider';
 import { useTheme } from '@mui/material/styles';
 import { FullDividerStyles } from '../../styles';
-import Stack from '@mui/material/Stack';
+import Box from '@mui/material/Box';
 
 export type VerifyEmailProps = {
     initialCode?: string;
@@ -57,16 +57,18 @@ export const VerifyEmail: React.FC<React.PropsWithChildren<React.PropsWithChildr
                 }}
                 variant="filled"
             />
-            <Stack flexDirection={'row'} sx={{ mt: 2 }}>
-                <Typography>{t('blui:SELF_REGISTRATION.VERIFY_EMAIL.VERIFICATION_CODE_PROMPT')}</Typography>
+            <Box component={'span'} sx={{ mt: 2 }}>
+                <Typography sx={{ display: 'inline' }}>
+                    {t('blui:SELF_REGISTRATION.VERIFY_EMAIL.VERIFICATION_CODE_PROMPT')}
+                </Typography>
                 <Typography
+                    sx={{ display: 'inline', '&:hover': { cursor: 'pointer' } }}
                     onClick={(): void => onResendVerificationEmail()}
                     color="primary"
-                    style={{ cursor: 'pointer' }}
                 >
                     &nbsp;<u>{t('blui:ACTIONS.RESEND')}</u>
                 </Typography>
-            </Stack>
+            </Box>
         </>
     );
 };

--- a/login-workflow/src/screens/subScreens/VerifyEmail.tsx
+++ b/login-workflow/src/screens/subScreens/VerifyEmail.tsx
@@ -61,7 +61,7 @@ export const VerifyEmail: React.FC<React.PropsWithChildren<React.PropsWithChildr
                 <Typography>
                     {t('blui:SELF_REGISTRATION.VERIFY_EMAIL.VERIFICATION_CODE_PROMPT')}
                     <Typography
-                        sx={{ fontSize: 'inherit', textTransform: 'initial' }}
+                        sx={{ fontSize: 'inherit', textTransform: 'initial', '&:hover': { cursor: 'pointer' } }}
                         onClick={(): void => onResendVerificationEmail()}
                         color="primary"
                         variant={'button'}

--- a/login-workflow/src/screens/subScreens/VerifyEmail.tsx
+++ b/login-workflow/src/screens/subScreens/VerifyEmail.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect } from 'react';
 import { useLanguageLocale } from '@brightlayer-ui/react-auth-shared';
-import Button from '@mui/material/Button';
 import Typography from '@mui/material/Typography';
 import TextField from '@mui/material/TextField';
 import Divider from '@mui/material/Divider';
 import { useTheme } from '@mui/material/styles';
 import { FullDividerStyles } from '../../styles';
+import Stack from '@mui/material/Stack';
 
 export type VerifyEmailProps = {
     initialCode?: string;
@@ -57,15 +57,16 @@ export const VerifyEmail: React.FC<React.PropsWithChildren<React.PropsWithChildr
                 }}
                 variant="filled"
             />
-            <Button
-                variant={'contained'}
-                color={'primary'}
-                disableElevation
-                onClick={(): void => onResendVerificationEmail()}
-                sx={{ mt: 2 }}
-            >
-                {t('blui:SELF_REGISTRATION.VERIFY_EMAIL.RESEND')}
-            </Button>
+            <Stack flexDirection={'row'} sx={{ mt: 2 }}>
+                <Typography>{t('blui:SELF_REGISTRATION.VERIFY_EMAIL.VERIFICATION_CODE_PROMPT')}</Typography>
+                <Typography
+                    onClick={(): void => onResendVerificationEmail()}
+                    color="primary"
+                    style={{ cursor: 'pointer' }}
+                >
+                    &nbsp;<u>{t('blui:ACTIONS.RESEND')}</u>
+                </Typography>
+            </Stack>
         </>
     );
 };

--- a/login-workflow/src/screens/subScreens/VerifyEmail.tsx
+++ b/login-workflow/src/screens/subScreens/VerifyEmail.tsx
@@ -57,17 +57,18 @@ export const VerifyEmail: React.FC<React.PropsWithChildren<React.PropsWithChildr
                 }}
                 variant="filled"
             />
-            <Box component={'span'} sx={{ mt: 2 }}>
-                <Typography sx={{ display: 'inline' }}>
+            <Box sx={{ mt: 2 }}>
+                <Typography>
                     {t('blui:SELF_REGISTRATION.VERIFY_EMAIL.VERIFICATION_CODE_PROMPT')}
-                </Typography>
-                <Typography
-                    sx={{ display: 'inline', textTransform: 'initial', '&:hover': { cursor: 'pointer' } }}
-                    onClick={(): void => onResendVerificationEmail()}
-                    color="primary"
-                    variant={'button'}
-                >
-                    &nbsp;<u>{t('blui:ACTIONS.RESEND')}</u>
+                    <Typography
+                        sx={{ fontSize: 'inherit', textTransform: 'initial' }}
+                        onClick={(): void => onResendVerificationEmail()}
+                        color="primary"
+                        variant={'button'}
+                    >
+                        {' '}
+                        <u>{t('blui:ACTIONS.RESEND')}</u>
+                    </Typography>
                 </Typography>
             </Box>
         </>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes BLUI-3927 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Update verify email & remove button
- Todo - will open PR in auth shared to correct the verbiage in a separate pull request to update both RN & React workflows. Updated verbiage should be 'Didn't receive email? Send Again' 
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Click on Register now & accept eula
- Enter email
- verify updated send verification 

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
