### PR TITLE
HOTFIX: Allow hiding the CreatePassword screen

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -5,13 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v3.2.0 (Unreleased)
+## v4.0.0 (Unreleased)
 
 ### Added
 
 -   A `ContactSupportSubscreen` component.
 -   A `BrandedCardContainer` component.
 -   Confirm password field error state message in `ChangePasswordForm`.
+-   Option to hide the Create Password screen during registration
 
 ### Changed
 

--- a/login-workflow/docs/customization.md
+++ b/login-workflow/docs/customization.md
@@ -7,7 +7,7 @@ The Login screen supports some simple customization (via the `AuthUIContextProvi
 -   You can pass in a custom header that will appear above the login form using the `loginHeader` prop. By default, we render your `productImage`.
 -   You can pass in a custom footer that will appear below the login form and registration links with any content you like (such as links to Privacy Policy, Terms of Service, etc.) using the `loginFooter` prop.
 -   You can customize the background of the workflow using the `background` prop including the color, tile image, etc.
--   You can disable and hide various aspects of the workflow using the following props: `enableInviteRegistration`, `enableResetPassword`, `showContactSupport`, `showCybersecurityBadge`, `showRememberMe`, `showSelfRegistration`.
+-   You can disable and hide various aspects of the workflow using the following props: `enableInviteRegistration`, `enableResetPassword`, `enableCreatePassword`, `showContactSupport`, `showCybersecurityBadge`, `showRememberMe`, `showSelfRegistration`.
 
 For more details, read the [full API details](https://github.com/etn-ccis/blui-react-auth-shared/tree/master/docs/API.md).
 

--- a/login-workflow/example/src/App.tsx
+++ b/login-workflow/example/src/App.tsx
@@ -49,7 +49,6 @@ export const AuthUIConfiguration: React.FC<React.PropsWithChildren> = (props) =>
             contactEmail={'something@email.com'}
             contactPhone={'1-800-123-4567'}
             projectImage={productLogo}
-            enableCreatePassword={false}
             loginFooter={
                 <Box sx={{ display: 'flex', alignItems: 'center' }}>
                     <Button

--- a/login-workflow/example/src/App.tsx
+++ b/login-workflow/example/src/App.tsx
@@ -49,6 +49,7 @@ export const AuthUIConfiguration: React.FC<React.PropsWithChildren> = (props) =>
             contactEmail={'something@email.com'}
             contactPhone={'1-800-123-4567'}
             projectImage={productLogo}
+            enableCreatePassword={false}
             loginFooter={
                 <Box sx={{ display: 'flex', alignItems: 'center' }}>
                     <Button

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -27,7 +27,7 @@
     },
     "prettier": "@brightlayer-ui/prettier-config",
     "dependencies": {
-        "@brightlayer-ui/react-auth-shared": "^3.7.4",
+        "@brightlayer-ui/react-auth-shared": "^4.0.0-alpha.0",
         "dompurify": "^2.2.9",
         "i18next-browser-languagedetector": "^6.1.0"
     },

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@brightlayer-ui/react-auth-workflow",
-    "version": "3.2.0",
+    "version": "4.0.0-alpha.0",
     "author": "Brightlayer UI <brightlayer-ui@eaton.com> (https://github.com/brightlayer-ui)",
     "license": "BSD-3-Clause",
     "description": "Re-usable workflow components for Authentication and Registration within Eaton applications.",

--- a/login-workflow/src/screens/InviteRegistrationPager.tsx
+++ b/login-workflow/src/screens/InviteRegistrationPager.tsx
@@ -294,7 +294,12 @@ export const InviteRegistrationPager: React.FC<React.PropsWithChildren<React.Pro
                 canGoForward: true,
                 canGoBack: false,
             },
-        ]);
+        ])
+        // Remove the CreatePassword screen if so configured
+        .filter((page) => {
+            if (page.name === 'CreatePassword' && !injectedUIContext.enableCreatePassword) return false;
+            return true;
+        });
 
     const isLastStep = currentPage === RegistrationPages.length - 1;
     const isFirstStep = currentPage === 0;

--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -372,12 +372,19 @@ export const SelfRegistrationPager: React.FC<React.PropsWithChildren<React.Props
                 canGoForward: true,
                 canGoBack: false,
             },
-        ]);
+        ])
+        // Remove the CreatePassword screen if so configured
+        .filter((page) => {
+            if (page.name === 'CreatePassword' && !injectedUIContext.enableCreatePassword) return false;
+            return true;
+        });
+
     const isLastStep = currentPage === RegistrationPages.length - 1;
     const isFirstStep = currentPage === 0;
     const CreateAccountPage = RegistrationPages.findIndex((item) => item.name === 'CreateAccount');
     const VerifyEmailPage = RegistrationPages.findIndex((item) => item.name === 'VerifyEmail');
     const CreatePasswordPage = RegistrationPages.findIndex((item) => item.name === 'CreatePassword');
+    const AccountDetailsPage = RegistrationPages.findIndex((item) => item.name === 'AccountDetails');
     const CompletePage = RegistrationPages.length - 1;
 
     // If there is a code and it is not confirmed, go to the verify screen
@@ -403,10 +410,10 @@ export const SelfRegistrationPager: React.FC<React.PropsWithChildren<React.Props
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [codeRequestSuccess]);
 
-    // If the email is validated successfully, go to the create password screen
+    // If the email is validated successfully, go to the create password screen (or account details)
     useEffect(() => {
         if (currentPage === VerifyEmailPage && validationSuccess) {
-            setCurrentPage(CreatePasswordPage);
+            setCurrentPage(injectedUIContext.enableCreatePassword ? CreatePasswordPage : AccountDetailsPage);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [validationSuccess]);

--- a/login-workflow/yarn.lock
+++ b/login-workflow/yarn.lock
@@ -1045,10 +1045,10 @@
   resolved "https://registry.yarnpkg.com/@brightlayer-ui/prettier-config/-/prettier-config-1.0.3.tgz#e40a7ae7435c6fd5118acbf249080e0aa81e93af"
   integrity sha512-EYm3+V7Qd+oYEF+8FadsXAZqXryEHHbGnrV1BMp9selhABjceqUqXPVE4Sn3SKWQdBNJ3En2A3EzgrzRbvRTaw==
 
-"@brightlayer-ui/react-auth-shared@^3.7.4":
-  version "3.7.4"
-  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-auth-shared/-/react-auth-shared-3.7.4.tgz#f0d0b931867bf90e42994c2dfff313b7a8a2b996"
-  integrity sha512-ef9i4PHfvkjbvSkKDrUIBSWbrsRVpHSPesxkRfd+rEimIpXdW+dLRVT6j3x4Ht1QRGvJa9m6IsNuvA4zzNE9JQ==
+"@brightlayer-ui/react-auth-shared@^4.0.0-alpha.0":
+  version "4.0.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@brightlayer-ui/react-auth-shared/-/react-auth-shared-4.0.0-alpha.0.tgz#a11d55bb5f83bf87bebfd525acc2667e2029e4b4"
+  integrity sha512-TZJxxhb5i3cDdZbaPXL+qwLzedbgs/U5IlymR9ELc1dDuN8GMLePQnEI7o9LLu0AjzUYtm3fq19U/oM3HEqCwQ==
 
 "@brightlayer-ui/react-components@^6.1.2-alpha.0":
   version "6.2.0"


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

This is a specific request needed by D-IT team to handle their Okta integration. This is a temporary fix that they will be able to use in an alpha release to get through their project before our finished refactor — it does not mean that this is how we will handle this capability in the long term.

Linked PR:
https://github.com/etn-ccis/blui-react-auth-shared/pull/108

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Remove the CreatePassword screen if the Auth configuration has disabled it

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:
- clone the repo
- `cd login-workflow`
- ~~`yarn initialize`~~
- ~~`cd shared-auth`~~
- ~~`git checkout feature/hide-create-password`~~
- ~~`cd ..`~~
- `yarn start:example`

- Add `enableCreatePassword={false}` to AuthUICotextProvider


> You should be able to use the default/dev branch pointer for the submodule now that the linked PR has been merged