### PR TITLE
Fix bad reset when acknowledging error

### DIFF
--- a/login-workflow/src/screens/SelfRegistrationPager.tsx
+++ b/login-workflow/src/screens/SelfRegistrationPager.tsx
@@ -159,13 +159,17 @@ export const SelfRegistrationPager: React.FC<React.PropsWithChildren<React.Props
             if (hasRegistrationTransitError) registrationActions.dispatch(RegistrationActions.registerUserReset());
             setHasAcknowledgedError(false);
         }
-        return (): void => {
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [hasAcknowledgedError]);
+
+    useEffect(
+        () => (): void => {
             registrationActions.dispatch(RegistrationActions.requestRegistrationCodeReset());
             registrationActions.dispatch(RegistrationActions.validateUserRegistrationReset());
             registrationActions.dispatch(RegistrationActions.registerUserReset());
-        };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [hasAcknowledgedError]);
+        },
+        [] // eslint-disable-line react-hooks/exhaustive-deps
+    );
 
     // Call the API to finish registration
     const attemptRegistration = useCallback(async (): Promise<void> => {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes an issue where the entire registration redux state is reset when acknowledging an error. See video submitted by DIT team: 
![c3bb8ee8-cacf-430f-9223-f3c38c5b759d](https://github.com/etn-ccis/blui-react-workflows/assets/29152776/ecde2a1c-b16f-4c9b-b204-f15f44299573)

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Only run the cleanup function on onMount instead of when acknowledged error variable updates (moved to a separate useEffect hook).

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

To see the original error, clone dev and do the following:

- In RegistrationUIActions file of demo, update the registration function to this:

```tsx
    completeRegistration: async (
        userData: {
            password: string;
            accountDetails: AccountDetailInformation;
        },
        validationCode: string,
        validationEmail?: string
    ): Promise<{ email: string; organizationName: string }> => {
        const email = 'example@email.com';
        const organizationName = 'Acme Co.';
        const userInfo = { email, organizationName };

        await sleep(1000);
        if (userData.accountDetails.firstName === 'error') {
            throw new Error('Sorry, there was a problem sending your request.');
        }
        return userInfo;
    },
```
- yarn start:example and run through the workflow
- when you get to the account details screen, set the firstName to 'error'
- When you dismiss the error dialog, you'll be sent back to the verify code screen (redux state has been reset)

Clone this branch with the fix and run the same steps...you'll remain on the account details page and the prior redux state is preserved.

> I'll publish this manually as an alpha for the DIT team once approved
