### PR TITLE
Add on enter key press events for login and resetpassword

### DIFF
--- a/login-workflow/example2/src/screens/new-architecture-test-screens/ResetPasswordScreen.tsx
+++ b/login-workflow/example2/src/screens/new-architecture-test-screens/ResetPasswordScreen.tsx
@@ -71,13 +71,16 @@ export const ResetPasswordScreen = (): JSX.Element => {
                         initialConfirmPasswordValue: confirmInput,
                         onPasswordChange: updateFields,
                         onSubmit: (): void => {
-                            // eslint-disable-next-line no-console
-                            console.log('submitting form...');
+                            if (passwordInput !== '' && confirmInput !== '' && passwordInput === confirmInput) {
+                                // eslint-disable-next-line no-console
+                                console.log('submitting form...');
+                                setShowSuccessScreen(true);
+                            }
                         },
                     }}
                     WorkflowCardActionsProps={{
                         showNext: true,
-                        nextLabel: 'Okay',
+                        nextLabel: 'Next',
                         canGoNext: passwordInput !== '' && confirmInput !== '' && passwordInput === confirmInput,
                         onNext: (): void => {
                             setShowSuccessScreen(true);

--- a/login-workflow/src/new-architecture/screens/LoginScreen/LoginScreenBase.tsx
+++ b/login-workflow/src/new-architecture/screens/LoginScreen/LoginScreenBase.tsx
@@ -348,6 +348,9 @@ export const LoginScreenBase: React.FC<React.PropsWithChildren<LoginScreenProps>
                                     usernameTextFieldProps?.onBlur && usernameTextFieldProps.onBlur(e);
                                     setShouldValidateUsername(true);
                                 }}
+                                onKeyPress={(e): void => {
+                                    if (e.key === 'Enter' && passwordField.current) passwordField.current.focus();
+                                }}
                             />
                         </Box>
                         <Box
@@ -380,12 +383,17 @@ export const LoginScreenBase: React.FC<React.PropsWithChildren<LoginScreenProps>
                                 onSubmit={(e: any): void => {
                                     // eslint-disable-next-line no-unused-expressions
                                     passwordTextFieldProps?.onSubmit && passwordTextFieldProps.onSubmit(e);
-                                    handleLoginSubmit(e.target.value);
+                                    handleLoginSubmit(e);
                                 }}
                                 onBlur={(e): void => {
                                     // eslint-disable-next-line no-unused-expressions
                                     passwordTextFieldProps?.onBlur && passwordTextFieldProps.onBlur(e);
                                     setShouldValidatePassword(true);
+                                }}
+                                onKeyPress={(e): void => {
+                                    // eslint-disable-next-line no-unused-expressions
+                                    passwordTextFieldProps?.onSubmit && passwordTextFieldProps.onSubmit(e);
+                                    handleLoginSubmit(e);
                                 }}
                             />
                         </Box>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes 4012.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Minor fixes that to the login and reset password screens and examples to ensure the user can continue through the form using the enter key
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- `yarn start:example2`
-  check the loginscreen base test page and the reset password screen and ensure you can continue through the form with the enter key.

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
