### PR TITLE
Fix login function prop being overwritten issue

### DIFF
--- a/login-workflow/example2/src/screens/new-architecture-test-screens/LoginScreenFullScreen.tsx
+++ b/login-workflow/example2/src/screens/new-architecture-test-screens/LoginScreenFullScreen.tsx
@@ -33,10 +33,10 @@ export const LoginScreenFullScreenTest = (): JSX.Element => {
                         // passwordTextFieldProps={{
                         //     required: true,
                         // }}
-                        onRememberMeChanged={(value: boolean): void => {
-                            // eslint-disable-next-line no-console
-                            console.log('onRememberMeChanged', value);
-                        }}
+                        // onRememberMeChanged={(value: boolean): void => {
+                        //     // eslint-disable-next-line no-console
+                        //     // console.log('onRememberMeChanged', value);
+                        // }}
                         // showRememberMe={false}
                         // onForgotPassword={(): void => {
                         //     // eslint-disable-next-line no-console

--- a/login-workflow/src/new-architecture/screens/LoginScreen/LoginScreen.tsx
+++ b/login-workflow/src/new-architecture/screens/LoginScreen/LoginScreen.tsx
@@ -73,15 +73,6 @@ export const LoginScreen: React.FC<React.PropsWithChildren<LoginScreenPropsPubli
             props.onRememberMeChanged?.(value);
         },
         loginButtonLabel = t('bluiAuth:ACTIONS.LOG_IN'),
-        onLogin = async (username: string, password: string, rememberMe: boolean): Promise<void> => {
-            try {
-                await actions().logIn(username, password, rememberMe);
-                props.onLogin?.(username, password, rememberMe);
-            } catch (error) {
-                // eslint-disable-next-line no-console
-                console.log(error);
-            }
-        },
         showForgotPassword = true,
         forgotPasswordLabel = t('bluiAuth:LABELS.FORGOT_PASSWORD'),
         onForgotPassword = (): void => navigate(routeConfig.FORGOT_PASSWORD),
@@ -118,7 +109,16 @@ export const LoginScreen: React.FC<React.PropsWithChildren<LoginScreenPropsPubli
             rememberMeInitialValue={rememberMeInitialValue}
             onRememberMeChanged={onRememberMeChanged}
             loginButtonLabel={loginButtonLabel}
-            onLogin={onLogin}
+            // eslint-disable-next-line @typescript-eslint/no-misused-promises
+            onLogin={async (username: string, password: string, rememberMe: boolean): Promise<void> => {
+                try {
+                    await actions().logIn(username, password, rememberMe);
+                    await props.onLogin?.(username, password, rememberMe);
+                } catch (error) {
+                    // eslint-disable-next-line no-console
+                    console.log(error);
+                }
+            }}
             showForgotPassword={showForgotPassword}
             forgotPasswordLabel={forgotPasswordLabel}
             onForgotPassword={onForgotPassword}

--- a/login-workflow/src/new-architecture/screens/LoginScreen/LoginScreenBase.tsx
+++ b/login-workflow/src/new-architecture/screens/LoginScreen/LoginScreenBase.tsx
@@ -170,7 +170,7 @@ export const LoginScreenBase: React.FC<React.PropsWithChildren<LoginScreenProps>
     );
 
     const handleLogin = (): void => {
-        if (onLogin) onLogin(username, password, rememberMe);
+        if (onLogin) void onLogin(username, password, rememberMe);
     };
 
     const handleForgotPassword = (): void => {
@@ -203,7 +203,7 @@ export const LoginScreenBase: React.FC<React.PropsWithChildren<LoginScreenProps>
     const handleLoginSubmit = (e: React.KeyboardEvent<HTMLDivElement>): void => {
         setHasAcknowledgedError(false);
         if (e.key === 'Enter' && isFormValid()) {
-            handleLogin();
+            void handleLogin();
         }
     };
 

--- a/login-workflow/src/new-architecture/screens/LoginScreen/types.ts
+++ b/login-workflow/src/new-architecture/screens/LoginScreen/types.ts
@@ -36,7 +36,7 @@ export type LoginScreenProps = WorkflowCardBaseProps & {
 
     // configure Login
     loginButtonLabel?: string;
-    onLogin?: (username?: string, password?: string, rememberMe?: boolean) => void;
+    onLogin?: (username?: string, password?: string, rememberMe?: boolean) => Promise<void> | void;
 
     // configure Forgot Password
     showForgotPassword?: boolean;


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes Issue where Auth Login function wasn't being called if a user passes in an onLogin value.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

-Fixes Issue where Auth Login function wasn't being called if a user passes in an onLogin value.


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Add a `console.log('here')` snippet inside of the example2 apps AuthUIActions to ensure that the Auth.Login function is called.
- Attempt to pass in an onLogin prop as well and make sure both the passed in method as well as the authui.login functions are called.

<!-- Useful for draft pull requests -->
