### PR TITLE
Added lower and upper bounds for initialScreenIndex in RegistrationWo…

### DIFF
--- a/login-workflow/src/new-architecture/components/RegistrationWorkflow/RegistrationWorkflow.test.tsx
+++ b/login-workflow/src/new-architecture/components/RegistrationWorkflow/RegistrationWorkflow.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import '@testing-library/jest-dom';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, RenderResult, screen } from '@testing-library/react';
 import { renderHook, act } from '@testing-library/react-hooks';
 import { RegistrationWorkflow, RegistrationWorkflowProps } from './RegistrationWorkflow';
 import Typography from '@mui/material/Typography';
@@ -13,31 +13,29 @@ const defaultProps: RegistrationWorkflowProps = {
     initialScreenIndex: 0,
 };
 
+const renderer = (props = defaultProps): RenderResult =>
+    render(
+        <RegistrationWorkflow {...props}>
+            <Typography>Screen 1</Typography>
+            <Typography>Screen 2</Typography>
+        </RegistrationWorkflow>
+    );
+
 describe('RegistrationWorkflow', () => {
     it('renders without crashing', () => {
-        render(<RegistrationWorkflow {...defaultProps}>Screen 1</RegistrationWorkflow>);
+        renderer();
         expect(screen.getByText('Screen 1')).toBeInTheDocument();
     });
 
     it('should render the multiple screens', () => {
-        render(
-            <RegistrationWorkflow initialScreenIndex={0}>
-                <Typography>Screen 1</Typography>
-                <Typography>Screen 2</Typography>
-            </RegistrationWorkflow>
-        );
+        renderer();
         expect(screen.getByText('Screen 1')).toBeInTheDocument();
     });
 
     it('should render the correct screen, when initialScreenIndex prop is passed', () => {
-        render(
-            <RegistrationWorkflow initialScreenIndex={1}>
-                <Typography>Indexed Screen 1</Typography>
-                <Typography>Indexed Screen 2</Typography>
-            </RegistrationWorkflow>
-        );
-        expect(screen.queryByText('Indexed Screen 1')).toBeNull();
-        expect(screen.getByText('Indexed Screen 2')).toBeInTheDocument();
+        renderer({ initialScreenIndex: 1 });
+        expect(screen.queryByText('Screen 1')).toBeNull();
+        expect(screen.getByText('Screen 2')).toBeInTheDocument();
     });
 
     it('should call nextScreen function', () => {
@@ -102,5 +100,15 @@ describe('RegistrationWorkflow', () => {
         /* @ts-ignore */
         expect(result.current.screenData['Other']['Screen1'].test).toBe('test');
         expect(result.current.screenData['Other']['Screen2'].test2).toBe('test2');
+    });
+
+    it('should check for lower bound of initialScreenIndex props', () => {
+        renderer({ initialScreenIndex: -1 });
+        expect(screen.getByText('Screen 1')).toBeInTheDocument();
+    });
+
+    it('should check for upper bound of initialScreenIndex props', () => {
+        renderer({ initialScreenIndex: 2 });
+        expect(screen.getByText('Screen 2')).toBeInTheDocument();
     });
 });

--- a/login-workflow/src/new-architecture/components/RegistrationWorkflow/RegistrationWorkflow.tsx
+++ b/login-workflow/src/new-architecture/components/RegistrationWorkflow/RegistrationWorkflow.tsx
@@ -9,8 +9,10 @@ export type RegistrationWorkflowProps = {
 export const RegistrationWorkflow: React.FC<React.PropsWithChildren<RegistrationWorkflowProps>> = (props) => {
     const { initialScreenIndex = 0, children } = props;
     const screens = [...(Array.isArray(children) ? children : [children])];
-    const [currentScreen, setCurrentScreen] = useState(initialScreenIndex);
     const totalScreens = screens.length;
+    const [currentScreen, setCurrentScreen] = useState(
+        initialScreenIndex < 0 ? 0 : initialScreenIndex > totalScreens - 1 ? totalScreens - 1 : initialScreenIndex
+    );
 
     const [screenData, setScreenData] = useState({
         Eula: {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # BLUI-4304

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Added lower and upper bounds for initialScreenIndex in RegistrationWorkflow

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- yarn start:example2
- In RegistrationWorkflowScreen try changing initialScreenIndex value to either less than 0 or more than 2

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
