### PR TITLE
add action for create password screen

### DIFF
--- a/login-workflow/example2/src/actions/RegistrationUIActions.tsx
+++ b/login-workflow/example2/src/actions/RegistrationUIActions.tsx
@@ -67,6 +67,15 @@ export const ProjectRegistrationUIActions: () => RegistrationUIActions = () => (
         return 'a1b2c3';
     },
 
+    /**
+     * A new user wants to create their password.
+     * The application will update entered password. Upon completion,
+     * the user will move to next screen.
+     *
+     * @param password password entered by user.
+     *
+     * @returns Resolve if successful, otherwise reject with an error message.
+     */
     createPassword: async (password: string): Promise<boolean> => {
         await sleep(800);
         if (isRandomFailure()) {

--- a/login-workflow/src/new-architecture/screens/CreatePasswordScreen/CreatePasswordScreen.tsx
+++ b/login-workflow/src/new-architecture/screens/CreatePasswordScreen/CreatePasswordScreen.tsx
@@ -24,8 +24,8 @@ export const CreatePasswordScreen: React.FC<CreatePasswordScreenProps> = (props)
     const passwordRequirements = defaultPasswordRequirements(t);
 
     const onNext = useCallback(async (): Promise<void> => {
-        setIsLoading(true);
         try {
+            setIsLoading(true);
             await actions().createPassword(passwordInput);
             nextScreen({
                 screenId: 'CreatePassword',

--- a/login-workflow/src/new-architecture/screens/CreatePasswordScreen/CreatePasswordScreen.tsx
+++ b/login-workflow/src/new-architecture/screens/CreatePasswordScreen/CreatePasswordScreen.tsx
@@ -3,10 +3,11 @@ import { CreatePasswordScreenBase } from './CreatePasswordScreenBase';
 import { useLanguageLocale } from '../../hooks';
 import { defaultPasswordRequirements } from '../../constants';
 import { CreatePasswordScreenProps } from './types';
-import { useRegistrationWorkflowContext } from '../../contexts';
+import { useRegistrationContext, useRegistrationWorkflowContext } from '../../contexts';
 
 export const CreatePasswordScreen: React.FC<CreatePasswordScreenProps> = (props) => {
     const { t } = useLanguageLocale();
+    const { actions } = useRegistrationContext();
     const regWorkflow = useRegistrationWorkflowContext();
     const {
         nextScreen,
@@ -19,14 +20,22 @@ export const CreatePasswordScreen: React.FC<CreatePasswordScreenProps> = (props)
     const confirmRef = useRef(null);
     const [passwordInput, setPasswordInput] = useState(password ?? '');
     const [confirmInput, setConfirmInput] = useState(confirmPassword ?? '');
+    const [isLoading, setIsLoading] = useState(false);
     const passwordRequirements = defaultPasswordRequirements(t);
 
-    const onNext = useCallback(() => {
-        nextScreen({
-            screenId: 'CreatePassword',
-            values: { password: passwordInput, confirmPassword: confirmInput },
-        });
-    }, [confirmInput, passwordInput, nextScreen]);
+    const onNext = useCallback(async (): Promise<void> => {
+        setIsLoading(true);
+        try {
+            await actions().createPassword(passwordInput);
+            nextScreen({
+                screenId: 'CreatePassword',
+                values: { password: passwordInput, confirmPassword: confirmInput },
+            });
+        } catch {
+            console.error('Error while creating password...');
+        }
+        setIsLoading(false);
+    }, [passwordInput, confirmInput, actions, nextScreen, setIsLoading]);
 
     const onPrevious = useCallback(() => {
         previousScreen({
@@ -80,6 +89,9 @@ export const CreatePasswordScreen: React.FC<CreatePasswordScreenProps> = (props)
                 void onPrevious();
             },
         },
+        WorkflowCardBaseProps: workflowCardBaseProps = {
+            loading: isLoading,
+        },
     } = props;
 
     const areValidMatchingPasswords = useCallback((): boolean => {
@@ -96,9 +108,10 @@ export const CreatePasswordScreen: React.FC<CreatePasswordScreenProps> = (props)
     return (
         <>
             <CreatePasswordScreenBase
+                WorkflowCardActionsProps={workflowCardActionsProps}
+                WorkflowCardBaseProps={workflowCardBaseProps}
                 WorkflowCardHeaderProps={workflowCardHeaderProps}
                 WorkflowCardInstructionProps={workflowCardInstructionProps}
-                WorkflowCardActionsProps={workflowCardActionsProps}
                 PasswordProps={{
                     ...passwordProps,
                     onPasswordChange: updateFields,


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes BLUI-4134.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:
During the demo following issue has been observed 
- Add action `createPassword` when the user clicks on the next button in the createPassword full screen.
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Go to http://localhost:3000/registration-workflow
- Go to create password screen 
- After clicking on the next button it should call the createPassword action API. (Please add console  https://github.com/etn-ccis/blui-react-workflows/pull/332/files#diff-7198102045b1014817d054fc26bccace57e0f72958a776d02e19aa7eaf4c34bdR80
to check function is calling or not
<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
