### PR TITLE
Bug/4384 remove forgot password screen base on next onback

### DIFF
--- a/login-workflow/example2/src/screens/new-architecture-test-screens/ForgotPasswordScreenBase.tsx
+++ b/login-workflow/example2/src/screens/new-architecture-test-screens/ForgotPasswordScreenBase.tsx
@@ -48,12 +48,10 @@ export const ForgotPasswordScreenBaseTest = (): JSX.Element => {
                         showPrevious: true,
                         previousLabel: 'Back',
                         canGoPrevious: true,
-                        onNext: (): void => {},
+                        onNext: (data: any): void => {
+                            setEmailInput(data?.email);
+                        },
                         onPrevious: (): void => navigate('/'),
-                    }}
-                    onNext={(email): boolean | string => {
-                        setEmailInput(email);
-                        return true;
                     }}
                     slots={{
                         /* eslint-disable @typescript-eslint/naming-convention */

--- a/login-workflow/example2/src/screens/new-architecture-test-screens/ForgotPasswordScreenBase.tsx
+++ b/login-workflow/example2/src/screens/new-architecture-test-screens/ForgotPasswordScreenBase.tsx
@@ -48,7 +48,7 @@ export const ForgotPasswordScreenBaseTest = (): JSX.Element => {
                         showPrevious: true,
                         previousLabel: 'Back',
                         canGoPrevious: true,
-                        onNext: (data: any): void => {
+                        onNext: (data): void => {
                             setEmailInput(data?.email);
                         },
                         onPrevious: (): void => navigate('/'),

--- a/login-workflow/src/new-architecture/components/WorkflowCard/WorkflowCard.types.ts
+++ b/login-workflow/src/new-architecture/components/WorkflowCard/WorkflowCard.types.ts
@@ -30,7 +30,7 @@ export type WorkflowCardActionsProps = CardActionsProps & {
     previousLabel?: string;
     nextLabel?: string;
     onPrevious?: () => void;
-    onNext?: () => void;
+    onNext?: (data?: { [key: string]: any }) => void;
     currentStep?: number;
     totalSteps?: number;
     fullWidthButton?: boolean;

--- a/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
+++ b/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
@@ -88,29 +88,6 @@ export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props)
             canGoNext,
             canGoPrevious: canGoBack,
         },
-        slots = {
-            SuccessScreen: () => (
-                <SuccessScreenBase
-                    WorkflowCardHeaderProps={{ title: t('bluiAuth:HEADER.FORGOT_PASSWORD') }}
-                    icon={<CheckCircle color={'primary'} sx={{ fontSize: 100, mb: 5 }} />}
-                    messageTitle={t('bluiCommon:MESSAGES.EMAIL_SENT')}
-                    message={
-                        <Trans i18nKey={'bluiAuth:FORGOT_PASSWORD.LINK_SENT_ALT'} values={{ email: emailInput }}>
-                            Link has been sent to <b>{emailInput}</b>.
-                        </Trans>
-                    }
-                    WorkflowCardActionsProps={{
-                        showNext: true,
-                        nextLabel: t('bluiCommon:ACTIONS.DONE'),
-                        canGoNext: true,
-                        onNext: (): void => {
-                            navigate(routeConfig.LOGIN);
-                        },
-                        fullWidthButton: true,
-                    }}
-                />
-            ),
-        },
     } = props;
 
     const errorDialog = (
@@ -137,7 +114,33 @@ export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props)
                     emailLabel={emailLabel}
                     initialEmailValue={initialEmailValue}
                     emailValidator={emailValidator}
-                    slots={slots}
+                    slots={{
+                        SuccessScreen: () => (
+                            <SuccessScreenBase
+                                WorkflowCardHeaderProps={{ title: t('bluiAuth:HEADER.FORGOT_PASSWORD') }}
+                                icon={<CheckCircle color={'primary'} sx={{ fontSize: 100, mb: 5 }} />}
+                                messageTitle={t('bluiCommon:MESSAGES.EMAIL_SENT')}
+                                message={
+                                    <Trans
+                                        i18nKey={'bluiAuth:FORGOT_PASSWORD.LINK_SENT_ALT'}
+                                        values={{ email: emailInput }}
+                                    >
+                                        Link has been sent to <b>{emailInput}</b>.
+                                    </Trans>
+                                }
+                                WorkflowCardActionsProps={{
+                                    showNext: true,
+                                    nextLabel: t('bluiCommon:ACTIONS.DONE'),
+                                    canGoNext: true,
+                                    onNext: (): void => {
+                                        navigate(routeConfig.LOGIN);
+                                    },
+                                    fullWidthButton: true,
+                                }}
+                                {...props}
+                            />
+                        ),
+                    }}
                 />
             )}
         </>

--- a/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
+++ b/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
@@ -99,6 +99,7 @@ export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props)
             open={showErrorDialog}
             onClose={(): void => {
                 setShowErrorDialog(false);
+                setIsLoading(false);
             }}
         />
     );

--- a/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
+++ b/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
@@ -18,6 +18,7 @@ export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props)
     const [emailInput, setEmailInput] = useState('');
     const [isLoading, setIsLoading] = useState(false);
     const [showErrorDialog, setShowErrorDialog] = useState(false);
+    const [showSuccessScreen, setShowSuccessScreen] = useState(props.showSuccessScreen);
 
     const EMAIL_REGEX = /^[A-Z0-9._%+'-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
 
@@ -26,6 +27,7 @@ export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props)
             try {
                 setIsLoading(true);
                 await actions().forgotPassword(email);
+                setShowSuccessScreen(true);
                 setIsLoading(false);
             } catch (e) {
                 setShowErrorDialog(true);
@@ -114,6 +116,7 @@ export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props)
                     emailLabel={emailLabel}
                     initialEmailValue={initialEmailValue}
                     emailValidator={emailValidator}
+                    showSuccessScreen={showSuccessScreen}
                     slots={{
                         SuccessScreen: () => (
                             <SuccessScreenBase

--- a/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/ForgotPasswordScreenBase.test.tsx
+++ b/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/ForgotPasswordScreenBase.test.tsx
@@ -161,48 +161,4 @@ describe('Forgot Password Screen Base', () => {
         expect(getByText('Instructions')).toBeInTheDocument();
         expect(getByText('Email Address')).toBeInTheDocument();
     });
-
-    it('should display error in a dialog, when there is an error during screen transition', () => {
-        const { getByText, rerender, getByLabelText } = render(
-            <ForgotPasswordScreenBase
-                WorkflowCardHeaderProps={{ title: 'Title' }}
-                WorkflowCardInstructionProps={{ instructions: 'Instructions' }}
-                emailLabel="Email Address"
-                WorkflowCardActionsProps={{
-                    onNext: mockOnNext(),
-                    showNext: true,
-                    nextLabel: 'Next',
-                    canGoNext: true,
-                    currentStep: 1,
-                    totalSteps: 6,
-                }}
-                onNext={(email): string => `Error ${email}`}
-            />
-        );
-
-        const verifyEmailInput = getByLabelText('Email Address');
-        fireEvent.change(verifyEmailInput, { target: { value: 'test@test.test' } });
-        fireEvent.blur(verifyEmailInput);
-
-        fireEvent.click(getByText('Next'));
-
-        rerender(
-            <ForgotPasswordScreenBase
-                WorkflowCardHeaderProps={{ title: 'Title' }}
-                WorkflowCardInstructionProps={{ instructions: 'Instructions' }}
-                emailLabel="Email Address"
-                WorkflowCardActionsProps={{
-                    onNext: mockOnNext(),
-                    showNext: true,
-                    nextLabel: 'Next',
-                    canGoNext: true,
-                    currentStep: 1,
-                    totalSteps: 6,
-                }}
-                onNext={(email): string => `Error ${email}`}
-            />
-        );
-
-        expect(screen.getByTestId('blui-simple-dialog')).toBeInTheDocument();
-    });
 });

--- a/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/ForgotPasswordScreenBase.tsx
+++ b/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/ForgotPasswordScreenBase.tsx
@@ -8,8 +8,6 @@ import {
     WorkflowCardInstructions,
 } from '../../components';
 import { ForgotPasswordScreenProps } from './types';
-import { SimpleDialog } from '../../../components';
-import { useLanguageLocale } from '../../hooks';
 
 export const ForgotPasswordScreenBase: React.FC<React.PropsWithChildren<ForgotPasswordScreenProps>> = (props) => {
     const {
@@ -19,6 +17,7 @@ export const ForgotPasswordScreenBase: React.FC<React.PropsWithChildren<ForgotPa
         emailValidator = (email: string): boolean | string => true,
         slotProps = {},
         slots: { SuccessScreen } = {},
+        showSuccessScreen,
     } = props;
 
     const cardBaseProps = props.WorkflowCardBaseProps || {};
@@ -30,9 +29,6 @@ export const ForgotPasswordScreenBase: React.FC<React.PropsWithChildren<ForgotPa
     const [isEmailValid, setIsEmailValid] = useState(emailValidator(initialEmailValue) ?? false);
     const [emailError, setEmailError] = useState('');
     const [shouldValidateEmail, setShouldValidateEmail] = useState(false);
-    const [showSuccessScreen, setShowSuccessScreen] = useState(false);
-    const [showErrorDialog, setShowErrorDialog] = useState('');
-    const { t } = useLanguageLocale();
 
     const handleEmailInputChange = useCallback(
         (email: string) => {
@@ -48,9 +44,7 @@ export const ForgotPasswordScreenBase: React.FC<React.PropsWithChildren<ForgotPa
     const handleOnNext = (): void => {
         const { onNext } = actionsProps;
         if (onNext) {
-            const result = onNext({ email: emailInput });
-            setShowSuccessScreen(typeof result === 'boolean' && result);
-            setShowErrorDialog(typeof result === 'string' ? result : '');
+            onNext({ email: emailInput });
         }
     };
 
@@ -60,16 +54,6 @@ export const ForgotPasswordScreenBase: React.FC<React.PropsWithChildren<ForgotPa
                 <SuccessScreen {...slotProps.SuccessScreen} />
             ) : (
                 <WorkflowCard {...cardBaseProps}>
-                    {showErrorDialog && (
-                        <SimpleDialog
-                            title={t('bluiCommon:MESSAGES.ERROR')}
-                            body={showErrorDialog}
-                            open={showErrorDialog.length > 0}
-                            onClose={(): void => {
-                                setShowErrorDialog('');
-                            }}
-                        />
-                    )}
                     <WorkflowCardHeader {...headerProps} />
                     <WorkflowCardBody>
                         <WorkflowCardInstructions divider {...instructionsProps} />
@@ -92,7 +76,7 @@ export const ForgotPasswordScreenBase: React.FC<React.PropsWithChildren<ForgotPa
                             }}
                             variant="filled"
                             error={shouldValidateEmail && !isEmailValid}
-                            helperText={(shouldValidateEmail && emailError) || showErrorDialog}
+                            helperText={shouldValidateEmail && emailError}
                             onBlur={(): void => setShouldValidateEmail(true)}
                         />
                     </WorkflowCardBody>

--- a/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/ForgotPasswordScreenBase.tsx
+++ b/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/ForgotPasswordScreenBase.tsx
@@ -17,8 +17,6 @@ export const ForgotPasswordScreenBase: React.FC<React.PropsWithChildren<ForgotPa
         initialEmailValue = '',
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         emailValidator = (email: string): boolean | string => true,
-        onNext,
-        onBack,
         slotProps = {},
         slots: { SuccessScreen } = {},
     } = props;
@@ -48,17 +46,11 @@ export const ForgotPasswordScreenBase: React.FC<React.PropsWithChildren<ForgotPa
     );
 
     const handleOnNext = (): void => {
-        if (onNext) {
-            const result = onNext(emailInput);
+        if (actionsProps.onNext) {
+            const result = actionsProps.onNext({ email: emailInput });
             setShowSuccessScreen(typeof result === 'boolean' && result);
             setShowErrorDialog(typeof result === 'string' ? result : '');
         }
-        actionsProps?.onNext?.();
-    };
-
-    const handleOnPrevious = (): void => {
-        if (onBack) onBack(emailInput);
-        actionsProps?.onPrevious?.();
     };
 
     return (
@@ -108,7 +100,6 @@ export const ForgotPasswordScreenBase: React.FC<React.PropsWithChildren<ForgotPa
                         {...actionsProps}
                         canGoNext={emailInput.length > 0 && isEmailValid && actionsProps.canGoNext}
                         onNext={handleOnNext}
-                        onPrevious={handleOnPrevious}
                     />
                 </WorkflowCard>
             )}

--- a/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/ForgotPasswordScreenBase.tsx
+++ b/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/ForgotPasswordScreenBase.tsx
@@ -46,8 +46,9 @@ export const ForgotPasswordScreenBase: React.FC<React.PropsWithChildren<ForgotPa
     );
 
     const handleOnNext = (): void => {
-        if (actionsProps.onNext) {
-            const result = actionsProps.onNext({ email: emailInput });
+        const { onNext } = actionsProps;
+        if (onNext) {
+            const result = onNext({ email: emailInput });
             setShowSuccessScreen(typeof result === 'boolean' && result);
             setShowErrorDialog(typeof result === 'string' ? result : '');
         }

--- a/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/types.ts
+++ b/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/types.ts
@@ -11,9 +11,6 @@ export type ForgotPasswordScreenProps = WorkflowCardProps & {
     // used to test the input for valid formatting
     emailValidator?: (email: string) => boolean | string;
 
-    // used to handle next button click
-    onNext?: (email: string) => boolean | string;
-
     // used for each slot in `ForgotPasswordScreenBase`
     slots?: {
         SuccessScreen?: (props: SuccessScreenProps) => JSX.Element;
@@ -44,9 +41,6 @@ export type ForgotPasswordScreenProps = WorkflowCardProps & {
 
     // used to enable to back button
     canGoBack?: boolean | (() => boolean);
-
-    // used to handle back button click
-    onBack?: (email: string) => void;
 
     // used to display next button
     showNextButton?: boolean;

--- a/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/types.ts
+++ b/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/types.ts
@@ -50,4 +50,7 @@ export type ForgotPasswordScreenProps = WorkflowCardProps & {
 
     // used to enable to next button
     canGoNext?: boolean | (() => boolean);
+
+    // used to determine whether to show the success screen or not
+    showSuccessScreen?: boolean;
 };

--- a/login-workflow/src/new-architecture/screens/VerifyCodeScreen/VerifyCodeScreen.tsx
+++ b/login-workflow/src/new-architecture/screens/VerifyCodeScreen/VerifyCodeScreen.tsx
@@ -13,7 +13,6 @@ import { useRegistrationContext, useRegistrationWorkflowContext } from '../../co
  * @param resendInstructions text to display ahead of the resend link/button
  * @param resendLabel label for the resend link/button
  * @param initialValue code used to pre-populate the field
- * @param updateCode get the update code when user click the send again link
  *
  * @category Component
  */
@@ -49,19 +48,22 @@ export const VerifyCodeScreen: React.FC<VerifyCodeScreenProps> = (props) => {
         initialValue = verifyCode,
     } = props;
 
-    const onNext = useCallback(async () => {
-        try {
-            setIsLoading(true);
-            await actions().validateUserRegistrationRequest(verifyCode);
-            nextScreen({
-                screenId: 'VerifyCode',
-                values: { code: verifyCode },
-            });
-            setIsLoading(false);
-        } catch {
-            console.error('Error fetching validation code!');
-        }
-    }, [verifyCode, nextScreen, actions]);
+    const handleOnNext = useCallback(
+        async (code: string) => {
+            try {
+                setIsLoading(true);
+                await actions().validateUserRegistrationRequest(code);
+                nextScreen({
+                    screenId: 'VerifyCode',
+                    values: { code: verifyCode },
+                });
+                setIsLoading(false);
+            } catch {
+                console.error('Error fetching validation code!');
+            }
+        },
+        [verifyCode, nextScreen, actions]
+    );
 
     const onPrevious = (): void => {
         previousScreen({
@@ -88,8 +90,9 @@ export const VerifyCodeScreen: React.FC<VerifyCodeScreenProps> = (props) => {
             canGoPrevious: true,
             currentStep: 2,
             totalSteps: 6,
-            onNext: (): void => {
-                void onNext();
+            onNext: ({ code }): void => {
+                setVerifyCode(code);
+                void handleOnNext(code);
             },
             onPrevious: (): void => {
                 void onPrevious();
@@ -109,7 +112,6 @@ export const VerifyCodeScreen: React.FC<VerifyCodeScreenProps> = (props) => {
             initialValue={initialValue}
             onResend={onResend}
             codeValidator={codeValidator}
-            updateCode={setVerifyCode}
         />
     );
 };

--- a/login-workflow/src/new-architecture/screens/VerifyCodeScreen/VerifyCodeScreenBase.tsx
+++ b/login-workflow/src/new-architecture/screens/VerifyCodeScreen/VerifyCodeScreenBase.tsx
@@ -23,8 +23,7 @@ import Typography from '@mui/material/Typography';
  */
 
 export const VerifyCodeScreenBase: React.FC<React.PropsWithChildren<VerifyCodeScreenProps>> = (props) => {
-    const { codeValidator, onResend, resendInstructions, resendLabel, verifyCodeInputLabel, initialValue, updateCode } =
-        props;
+    const { codeValidator, onResend, resendInstructions, resendLabel, verifyCodeInputLabel, initialValue } = props;
 
     const cardBaseProps = props.WorkflowCardBaseProps || {};
     const headerProps = props.WorkflowCardHeaderProps || {};
@@ -41,13 +40,16 @@ export const VerifyCodeScreenBase: React.FC<React.PropsWithChildren<VerifyCodeSc
             setVerifyCode(code);
             if (codeValidator) {
                 const validatorResponse = codeValidator(code);
-                if (updateCode) updateCode(code);
                 setIsCodeValid(typeof validatorResponse === 'boolean' ? validatorResponse : false);
                 setCodeError(typeof validatorResponse === 'string' ? validatorResponse : '');
             }
         },
-        [codeValidator, updateCode]
+        [codeValidator]
     );
+
+    const handleOnNext = (): void => {
+        if (actionsProps.onNext) actionsProps.onNext({ code: verifyCode });
+    };
 
     return (
         <WorkflowCard {...cardBaseProps}>
@@ -63,7 +65,7 @@ export const VerifyCodeScreenBase: React.FC<React.PropsWithChildren<VerifyCodeSc
                     }}
                     onKeyPress={(e): void => {
                         if (e.key === 'Enter' && verifyCode.length > 0 && isCodeValid && actionsProps.canGoNext)
-                            actionsProps?.onNext?.();
+                            handleOnNext();
                     }}
                     variant="filled"
                     error={shouldValidateCode && !isCodeValid}
@@ -89,7 +91,8 @@ export const VerifyCodeScreenBase: React.FC<React.PropsWithChildren<VerifyCodeSc
                 {...actionsProps}
                 divider
                 canGoNext={verifyCode.length > 0 && isCodeValid && actionsProps.canGoNext}
-            ></WorkflowCardActions>
+                onNext={handleOnNext}
+            />
         </WorkflowCard>
     );
 };

--- a/login-workflow/src/new-architecture/screens/VerifyCodeScreen/VerifyCodeScreenBase.tsx
+++ b/login-workflow/src/new-architecture/screens/VerifyCodeScreen/VerifyCodeScreenBase.tsx
@@ -48,7 +48,8 @@ export const VerifyCodeScreenBase: React.FC<React.PropsWithChildren<VerifyCodeSc
     );
 
     const handleOnNext = (): void => {
-        if (actionsProps.onNext) actionsProps.onNext({ code: verifyCode });
+        const { onNext } = actionsProps;
+        if (onNext) onNext({ code: verifyCode });
     };
 
     return (

--- a/login-workflow/src/new-architecture/screens/VerifyCodeScreen/types.ts
+++ b/login-workflow/src/new-architecture/screens/VerifyCodeScreen/types.ts
@@ -1,4 +1,3 @@
-import { Dispatch, SetStateAction } from 'react';
 import { WorkflowCardProps } from '../../components/WorkflowCard/WorkflowCard.types';
 
 export type VerifyCodeScreenProps = WorkflowCardProps & {
@@ -19,7 +18,4 @@ export type VerifyCodeScreenProps = WorkflowCardProps & {
 
     // used to set the label for verify code input
     verifyCodeInputLabel?: string;
-
-    // callback used to update verification code
-    updateCode?: Dispatch<SetStateAction<string>>;
 };


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # BLUI-4384

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Removed on next and on back props from forgot password screen
- Updated the type of onNext

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

![Screenshot 2023-07-04 at 2 36 40 PM (2)](https://github.com/etn-ccis/blui-react-workflows/assets/120575281/7fef3f6b-458d-40df-a306-d070c9a68857)

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- yarn link:workflow2
- yarn start:example2

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
