### PR TITLE
Added password requirements empty check in set password

### DIFF
--- a/login-workflow/src/new-architecture/components/SetPassword/SetPassword.tsx
+++ b/login-workflow/src/new-architecture/components/SetPassword/SetPassword.tsx
@@ -92,11 +92,13 @@ export const SetPassword: React.FC<React.PropsWithChildren<SetPasswordProps>> = 
                 error={shouldValidatePassword && !isValidPassword()}
                 onBlur={(): void => setShouldValidatePassword(true)}
             />
-            <PasswordRequirements
-                sx={{ mt: 2 }}
-                passwordText={passwordInput}
-                passwordRequirements={passwordRequirements}
-            />
+            {passwordRequirements && passwordRequirements.length > 0 && (
+                <PasswordRequirements
+                    sx={{ mt: 2 }}
+                    passwordText={passwordInput}
+                    passwordRequirements={passwordRequirements}
+                />
+            )}
             <SecureTextField
                 id="confirm"
                 data-testid="confirm"

--- a/login-workflow/src/new-architecture/components/SetPassword/types.ts
+++ b/login-workflow/src/new-architecture/components/SetPassword/types.ts
@@ -14,7 +14,7 @@ export type SetPasswordProps = {
     initialNewPasswordValue?: string;
     confirmPasswordLabel?: string;
     initialConfirmPasswordValue?: string;
-    passwordRequirements?: PasswordRequirement[];
+    passwordRequirements?: PasswordRequirement[] | [];
     passwordRef?: MutableRefObject<any>;
     confirmRef?: MutableRefObject<any>;
     passwordNotMatchError?: string;

--- a/login-workflow/src/new-architecture/screens/CreatePasswordScreen/CreatePasswordScreen.test.tsx
+++ b/login-workflow/src/new-architecture/screens/CreatePasswordScreen/CreatePasswordScreen.test.tsx
@@ -107,6 +107,32 @@ describe('Create Password Screen', () => {
         expect(mockOnNext).toHaveBeenCalled();
     });
 
+    it('should enable next button, when passwordRequirements prop is empty', () => {
+        const { getByLabelText } = renderer({
+            WorkflowCardActionsProps: {
+                onNext: mockOnNext(),
+                showNext: true,
+                nextLabel: 'Next',
+            },
+            PasswordProps: {
+                newPasswordLabel: 'Password',
+                confirmPasswordLabel: 'Confirm Password',
+                onPasswordChange: jest.fn(),
+                passwordRequirements: [],
+            },
+        });
+
+        const passwordField = getByLabelText('Password');
+        const confirmPasswordField = getByLabelText('Confirm Password');
+
+        fireEvent.change(passwordField, { target: { value: 'A' } });
+        fireEvent.blur(passwordField);
+        fireEvent.change(confirmPasswordField, { target: { value: 'A' } });
+        fireEvent.blur(confirmPasswordField);
+
+        expect(screen.getByText(/Next/i)).toBeEnabled();
+    });
+
     it('should call onPrevious, when Back button clicked', () => {
         renderer({
             WorkflowCardActionsProps: {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # BLUI-4340

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Added password requirements empty check in set password
- Added test case 

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

<img width="1775" alt="Screenshot 2023-07-07 at 1 10 54 PM" src="https://github.com/etn-ccis/blui-react-workflows/assets/120575281/cfb255b2-41bd-4188-b527-bd7eecab9ba1">


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Make changes to any of the comp which uses SetPassword (e.g. CreatePassword) to make passwordRequirements as []
- Make the necessary changes in the functions/hooks uses passwordRequirements.length
- yarn link:workflow2
- yarn start:example2

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
