### PR TITLE
updated the onPrevious action verifcode prefill issue fixed

### DIFF
--- a/login-workflow/src/new-architecture/components/WorkflowCard/WorkflowCard.types.ts
+++ b/login-workflow/src/new-architecture/components/WorkflowCard/WorkflowCard.types.ts
@@ -29,7 +29,7 @@ export type WorkflowCardActionsProps = CardActionsProps & {
     showNext?: boolean;
     previousLabel?: string;
     nextLabel?: string;
-    onPrevious?: () => void;
+    onPrevious?: (data?: { [key: string]: any }) => void;
     onNext?: (data?: { [key: string]: any }) => void;
     currentStep?: number;
     totalSteps?: number;

--- a/login-workflow/src/new-architecture/screens/VerifyCodeScreen/VerifyCodeScreen.tsx
+++ b/login-workflow/src/new-architecture/screens/VerifyCodeScreen/VerifyCodeScreen.tsx
@@ -22,23 +22,21 @@ export const VerifyCodeScreen: React.FC<VerifyCodeScreenProps> = (props) => {
     const regWorkflow = useRegistrationWorkflowContext();
     const { actions } = useRegistrationContext();
     const { nextScreen, previousScreen, screenData } = regWorkflow;
+    const { emailAddress } = screenData.CreateAccount;
 
     const [verifyCode, setVerifyCode] = useState(screenData.VerifyCode.code);
     const [isLoading, setIsLoading] = useState(false);
 
-    const requestResendCode = useCallback(
-        async (email?: string): Promise<void> => {
-            try {
-                setIsLoading(true);
-                await actions().requestRegistrationCode(email);
-            } catch {
-                console.error('Error fetching resend verification code!');
-            } finally {
-                setIsLoading(false);
-            }
-        },
-        [actions]
-    );
+    const requestResendCode = useCallback(async (): Promise<void> => {
+        try {
+            setIsLoading(true);
+            await actions().requestRegistrationCode(emailAddress ? emailAddress : '');
+        } catch {
+            console.error('Error fetching resend verification code!');
+        } finally {
+            setIsLoading(false);
+        }
+    }, [emailAddress, actions]);
 
     const {
         codeValidator = (code: string): boolean | string =>
@@ -70,10 +68,10 @@ export const VerifyCodeScreen: React.FC<VerifyCodeScreenProps> = (props) => {
         [nextScreen, actions]
     );
 
-    const onPrevious = (): void => {
+    const onPrevious = (code: string): void => {
         previousScreen({
             screenId: 'VerifyCode',
-            values: { code: verifyCode },
+            values: { code },
         });
     };
 
@@ -104,8 +102,8 @@ export const VerifyCodeScreen: React.FC<VerifyCodeScreenProps> = (props) => {
             void handleOnNext(data.code);
             WorkflowCardActionsProps?.onNext();
         },
-        onPrevious: (): void => {
-            void onPrevious();
+        onPrevious: (data: any): void => {
+            void onPrevious(data.code);
             WorkflowCardActionsProps?.onPrevious();
         },
     };

--- a/login-workflow/src/new-architecture/screens/VerifyCodeScreen/VerifyCodeScreenBase.tsx
+++ b/login-workflow/src/new-architecture/screens/VerifyCodeScreen/VerifyCodeScreenBase.tsx
@@ -52,6 +52,11 @@ export const VerifyCodeScreenBase: React.FC<React.PropsWithChildren<VerifyCodeSc
         if (onNext) onNext({ code: verifyCode });
     };
 
+    const handleOnPrevious = (): void => {
+        const { onPrevious } = actionsProps;
+        if (onPrevious) onPrevious({ code: verifyCode });
+    };
+
     return (
         <WorkflowCard {...cardBaseProps}>
             <WorkflowCardHeader {...headerProps}></WorkflowCardHeader>
@@ -93,6 +98,7 @@ export const VerifyCodeScreenBase: React.FC<React.PropsWithChildren<VerifyCodeSc
                 divider
                 canGoNext={verifyCode.length > 0 && isCodeValid && actionsProps.canGoNext}
                 onNext={handleOnNext}
+                onPrevious={handleOnPrevious}
             />
         </WorkflowCard>
     );


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # updated the onPrevious action verifcode prefill issue fixed.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- when user enters the code in the field, and clicks on back button and again click on next to revisit verify code screen, previously entered code should be prefilled - issue fixed
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-  yarn start:example2
- click the Debug buttton to select the Registration workflow
- start the registration workflow to accept eula and enter emailaddress then go to verify code screen. Enter the verify code in the input box and click on back button then again come back to verify code screen. Now you can check to see the prefilled verify code value in the input box. 

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
