### PR TITLE
Feature-4325/Update forgot password screen to have link styles applied to phone number

### DIFF
--- a/login-workflow/src/new-architecture/screens/ContactScreen/ContactScreenBase.tsx
+++ b/login-workflow/src/new-architecture/screens/ContactScreen/ContactScreenBase.tsx
@@ -5,7 +5,7 @@ import { ContactScreenProps } from './types';
 import Box, { BoxProps } from '@mui/material/Box';
 import { ContactScreenClassKey, getContactScreenUtilityClass } from './utilityClasses';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
-import { LinkStyles } from '../../../styles';
+import { LinkStyles } from '../../styles';
 
 /**
  * Component renders a screen with contact information for support with the application.

--- a/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
+++ b/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
@@ -7,9 +7,21 @@ import { useLanguageLocale } from '../../hooks';
 import { SuccessScreenBase } from '../SuccessScreen';
 import { ForgotPasswordScreenBase } from './ForgotPasswordScreenBase';
 import { ForgotPasswordScreenProps } from './types';
-import { LinkStyles } from '../../../styles';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+
+const LinkStyles = {
+    fontWeight: 600,
+    textTransform: 'none',
+    textDecoration: 'none',
+    color: 'primary.main',
+    '&:visited': {
+        color: 'inherit',
+    },
+    '&:hover': {
+        cursor: 'pointer',
+    },
+};
 
 export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props) => {
     const { t } = useLanguageLocale();
@@ -71,9 +83,9 @@ export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props)
                     values={{ phone: contactPhone, responseTime }}
                 >
                     Please enter your email, we will respond in <b>{responseTime}</b>. For urgent issues please call{' '}
-                    <Box component="a" href={`tel:${contactPhone}`} sx={LinkStyles}>
+                    <Typography variant="button" sx={{ ...LinkStyles, fontSize: 'inherit' }}>
                         {contactPhone}
-                    </Box>
+                    </Typography>
                     .
                 </Trans>
             </Typography>

--- a/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
+++ b/login-workflow/src/new-architecture/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
@@ -7,21 +7,8 @@ import { useLanguageLocale } from '../../hooks';
 import { SuccessScreenBase } from '../SuccessScreen';
 import { ForgotPasswordScreenBase } from './ForgotPasswordScreenBase';
 import { ForgotPasswordScreenProps } from './types';
-import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-
-const LinkStyles = {
-    fontWeight: 600,
-    textTransform: 'none',
-    textDecoration: 'none',
-    color: 'primary.main',
-    '&:visited': {
-        color: 'inherit',
-    },
-    '&:hover': {
-        cursor: 'pointer',
-    },
-};
+import { LinkStyles } from '../../styles';
 
 export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props) => {
     const { t } = useLanguageLocale();
@@ -83,7 +70,7 @@ export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props)
                     values={{ phone: contactPhone, responseTime }}
                 >
                     Please enter your email, we will respond in <b>{responseTime}</b>. For urgent issues please call{' '}
-                    <Typography variant="button" sx={{ ...LinkStyles, fontSize: 'inherit' }}>
+                    <Typography component="a" href={`tel:${contactPhone}`} sx={LinkStyles}>
                         {contactPhone}
                     </Typography>
                     .

--- a/login-workflow/src/new-architecture/screens/LoginScreen/LoginScreenBase.tsx
+++ b/login-workflow/src/new-architecture/screens/LoginScreen/LoginScreenBase.tsx
@@ -15,6 +15,7 @@ import * as Colors from '@brightlayer-ui/colors';
 import { HELPER_TEXT_HEIGHT } from '../../utils/constants';
 import { LoginScreenClassKey, getLoginScreenUtilityClass } from './utilityClasses';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
+import { LinkStyles } from '../../styles';
 
 /**
  * Component that renders a login screen that prompts a user to enter a username and password to login.
@@ -50,19 +51,6 @@ import { unstable_composeClasses as composeClasses } from '@mui/base';
  *
  * @category Component
  */
-
-const LinkStyles = {
-    fontWeight: 600,
-    textTransform: 'none',
-    textDecoration: 'none',
-    color: 'primary.main',
-    '&:visited': {
-        color: 'inherit',
-    },
-    '&:hover': {
-        cursor: 'pointer',
-    },
-};
 
 const useUtilityClasses = (ownerState: LoginScreenProps): Record<LoginScreenClassKey, string> => {
     const { classes } = ownerState;

--- a/login-workflow/src/new-architecture/styles/index.tsx
+++ b/login-workflow/src/new-architecture/styles/index.tsx
@@ -1,0 +1,12 @@
+export const LinkStyles = {
+    fontWeight: 600,
+    textTransform: 'none',
+    textDecoration: 'none',
+    color: 'primary.main',
+    '&:visited': {
+        color: 'inherit',
+    },
+    '&:hover': {
+        cursor: 'pointer',
+    },
+};


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #[BLUI-4325](https://jira-prod.tcc.etn.com/browse/BLUI-4325) .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Updated the phone number style in ForgotPassword Screen as ContactUs screen

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)
<img width="1440" alt="Screenshot 2023-07-14 at 8 07 27 PM" src="https://github.com/etn-ccis/blui-react-workflows/assets/130662346/63c3735d-8848-4d33-afe4-10f97ebecdcf">


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- yarn start:example2
- Click on Forgot Password Full Screen

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
