### PR TITLE
Fixed issue with enabling next button in set password

### DIFF
--- a/login-workflow/example2/src/screens/new-architecture-test-screens/CreatePasswordScreenTest.tsx
+++ b/login-workflow/example2/src/screens/new-architecture-test-screens/CreatePasswordScreenTest.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect, useRef } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import {
     defaultPasswordRequirements,
     useLanguageLocale,
@@ -30,10 +30,6 @@ export const CreatePasswordScreenTest = (): JSX.Element => {
         },
         [setPasswordInput, setConfirmInput]
     );
-
-    useEffect(() => {
-        setPasswordInput(areValidMatchingPasswords() ? passwordInput : '');
-    }, [setPasswordInput, passwordInput, confirmInput, areValidMatchingPasswords]);
 
     return (
         <Box sx={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
@@ -77,7 +73,11 @@ export const CreatePasswordScreenTest = (): JSX.Element => {
                     WorkflowCardActionsProps={{
                         showNext: true,
                         nextLabel: 'Next',
-                        canGoNext: passwordInput !== '' && confirmInput !== '' && passwordInput === confirmInput,
+                        canGoNext:
+                            passwordInput !== '' &&
+                            confirmInput !== '' &&
+                            passwordInput === confirmInput &&
+                            areValidMatchingPasswords(),
                         showPrevious: true,
                         previousLabel: 'Back',
                         canGoPrevious: true,

--- a/login-workflow/src/new-architecture/components/ChangePasswordDialog/ChangePasswordDialog.test.tsx
+++ b/login-workflow/src/new-architecture/components/ChangePasswordDialog/ChangePasswordDialog.test.tsx
@@ -54,6 +54,7 @@ describe('Change Password Dialog tests', () => {
                 newPasswordLabel: 'New Password',
                 confirmPasswordLabel: 'Confirm New Password',
                 onPasswordChange: updateFields,
+                passwordRequirements: [],
             },
         });
 

--- a/login-workflow/src/new-architecture/components/SetPassword/SetPassword.test.tsx
+++ b/login-workflow/src/new-architecture/components/SetPassword/SetPassword.test.tsx
@@ -119,6 +119,8 @@ describe('SetPassword', () => {
     });
 
     it('should display the green check icon, when passwords match', () => {
+        const props = { ...defaultProps };
+        props.passwordRequirements = [];
         const { getByLabelText, getByTestId, queryByTestId, rerender } = renderer();
 
         const passwordField = getByLabelText('Password');
@@ -137,7 +139,7 @@ describe('SetPassword', () => {
         rerender(
             <AuthContextProvider {...authContextProps}>
                 <AuthUIContextProvider authActions={jest.fn()} registrationActions={jest.fn()}>
-                    <SetPassword {...defaultProps} />
+                    <SetPassword {...props} />
                 </AuthUIContextProvider>
             </AuthContextProvider>
         );

--- a/login-workflow/src/new-architecture/components/SetPassword/SetPassword.tsx
+++ b/login-workflow/src/new-architecture/components/SetPassword/SetPassword.tsx
@@ -114,7 +114,7 @@ export const SetPassword: React.FC<React.PropsWithChildren<SetPasswordProps>> = 
                 error={hasConfirmPasswordError()}
                 helperText={hasConfirmPasswordError() ? passwordNotMatchError : ''}
                 icon={
-                    confirmInput.length !== 0 && confirmInput === passwordInput ? (
+                    confirmInput.length !== 0 && isValidPassword() && confirmInput === passwordInput ? (
                         <CheckCircleOutlinedIcon data-testid="check" color="success" />
                     ) : undefined
                 }

--- a/login-workflow/src/new-architecture/contexts/RegistrationWorkflowContext/index.ts
+++ b/login-workflow/src/new-architecture/contexts/RegistrationWorkflowContext/index.ts
@@ -13,7 +13,7 @@ import { RegistrationWorkflowContextProvider } from './provider';
 export const useRegistrationWorkflowContext = (): RegistrationWorkflowContextProps => {
     const context = useContext(RegistrationWorkflowContext);
     if (context === null) {
-        throw new Error('useRegistrationWorkflowContext must be used within an RegistrationContextProvider');
+        throw new Error('useRegistrationWorkflowContext must be used within an RegistrationWorkflowContextProvider');
     }
     return context;
 };

--- a/login-workflow/src/new-architecture/screens/CreatePasswordScreen/CreatePasswordScreen.tsx
+++ b/login-workflow/src/new-architecture/screens/CreatePasswordScreen/CreatePasswordScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { CreatePasswordScreenBase } from './CreatePasswordScreenBase';
 import { useLanguageLocale } from '../../hooks';
 import { defaultPasswordRequirements } from '../../constants';
@@ -101,7 +101,11 @@ export const CreatePasswordScreen: React.FC<CreatePasswordScreenProps> = (props)
     const workflowCardActionsProps = {
         showNext: true,
         nextLabel: t('bluiCommon:ACTIONS.NEXT'),
-        canGoNext: passwordInput !== '' && confirmInput !== '' && passwordInput === confirmInput,
+        canGoNext:
+            passwordInput !== '' &&
+            confirmInput !== '' &&
+            passwordInput === confirmInput &&
+            areValidMatchingPasswords(),
         showPrevious: true,
         previousLabel: t('bluiCommon:ACTIONS.BACK'),
         canGoPrevious: true,
@@ -117,10 +121,6 @@ export const CreatePasswordScreen: React.FC<CreatePasswordScreenProps> = (props)
             WorkflowCardActionsProps?.onPrevious?.();
         },
     };
-
-    useEffect(() => {
-        setPasswordInput(areValidMatchingPasswords() ? passwordInput : '');
-    }, [setPasswordInput, passwordInput, confirmInput, areValidMatchingPasswords]);
 
     return (
         <>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # BLUI-4340

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Added next button enabling issue with empty password requirements

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- 
![Screenshot 2023-07-14 at 9 29 11 PM (2)](https://github.com/etn-ccis/blui-react-workflows/assets/120575281/74730c62-c5f7-4d60-ae28-cd6eb26d615c)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- yarn start:example2
- Click on Debug
- Click on Create Password

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

- This issue was found in https://github.com/etn-ccis/blui-react-workflows/pull/336
