### PR TITLE
Feature/blui 4401 error messaging enhancements

### DIFF
--- a/login-workflow/example2/src/actions/AuthUIActions.tsx
+++ b/login-workflow/example2/src/actions/AuthUIActions.tsx
@@ -87,11 +87,13 @@ export const ProjectAuthUIActions: AuthUIActionsWithSecurity = (securityHelper) 
      */
     logIn: async (email: string, password: string, rememberMe: boolean): Promise<void> => {
         await sleep(1000);
+        // eslint-disable-next-line no-console
+        console.log('actions login called...');
 
         throw new Error('My Custom Error', {
             cause: {
                 title: 'Custom Title',
-                message: 'My custom error message',
+                errorMessage: 'My custom error message',
             },
         });
 

--- a/login-workflow/example2/src/actions/AuthUIActions.tsx
+++ b/login-workflow/example2/src/actions/AuthUIActions.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { AuthUIActions, SecurityContextActions } from '@brightlayer-ui/react-auth-workflow';
 import { LocalStorage } from '../store/local-storage';
+import { useApp } from '../contexts/AppContextProvider';
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -87,7 +88,12 @@ export const ProjectAuthUIActions: AuthUIActionsWithSecurity = (securityHelper) 
     logIn: async (email: string, password: string, rememberMe: boolean): Promise<void> => {
         await sleep(1000);
 
-        // throw new Error('My Custom Error');
+        throw new Error('My Custom Error', {
+            cause: {
+                title: 'Custom Title',
+                message: 'My custom error message',
+            },
+        });
 
         if (isRandomFailure()) {
             // reject(new Error('LOGIN.GENERIC_ERROR'));

--- a/login-workflow/example2/src/screens/example-cleanup/Login.tsx
+++ b/login-workflow/example2/src/screens/example-cleanup/Login.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from 'react-router';
 import { ProjectAuthUIActions } from '../../actions/AuthUIActions';
 
 export const Login = (): JSX.Element => {
-    const { language, setIsAuthenticated } = useApp();
+    const { language } = useApp();
     const navigate = useNavigate();
     const securityContextActions = useSecurityActions();
 
@@ -19,6 +19,12 @@ export const Login = (): JSX.Element => {
                     language={language}
                     navigate={navigate}
                     routeConfig={{}}
+                    errorConfig={{
+                        mode: 'message-box',
+                        dismissible: true,
+                        position: 'top',
+                        dismissButtonText: 'Close',
+                    }}
                 >
                     <>
                         <Button
@@ -35,11 +41,11 @@ export const Login = (): JSX.Element => {
                             {`DEBUG`}
                         </Button>
                         <LoginScreen
-                            onLogin={(username, password): void => {
+                            onLogin={(username: any, password: any): void => {
                                 // eslint-disable-next-line no-console
                                 console.log('onLogin', username, password);
-                                setIsAuthenticated(true);
-                                navigate('/guarded');
+                                // setIsAuthenticated(true);
+                                // navigate('/guarded');
                             }}
                             usernameTextFieldProps={{
                                 inputProps: {

--- a/login-workflow/example2/src/screens/example-cleanup/Login.tsx
+++ b/login-workflow/example2/src/screens/example-cleanup/Login.tsx
@@ -23,7 +23,6 @@ export const Login = (): JSX.Element => {
                         mode: 'message-box',
                         dismissible: true,
                         position: 'top',
-                        dismissButtonText: 'Close',
                     }}
                 >
                     <>

--- a/login-workflow/example2/src/screens/example-cleanup/Login.tsx
+++ b/login-workflow/example2/src/screens/example-cleanup/Login.tsx
@@ -7,7 +7,7 @@ import { useNavigate } from 'react-router';
 import { ProjectAuthUIActions } from '../../actions/AuthUIActions';
 
 export const Login = (): JSX.Element => {
-    const { language } = useApp();
+    const { language, setIsAuthenticated } = useApp();
     const navigate = useNavigate();
     const securityContextActions = useSecurityActions();
 
@@ -44,8 +44,8 @@ export const Login = (): JSX.Element => {
                             onLogin={(username: any, password: any): void => {
                                 // eslint-disable-next-line no-console
                                 console.log('onLogin', username, password);
-                                // setIsAuthenticated(true);
-                                // navigate('/guarded');
+                                setIsAuthenticated(true);
+                                navigate('/guarded');
                             }}
                             usernameTextFieldProps={{
                                 inputProps: {

--- a/login-workflow/example2/src/screens/new-architecture-test-screens/LoginScreenBase.tsx
+++ b/login-workflow/example2/src/screens/new-architecture-test-screens/LoginScreenBase.tsx
@@ -60,26 +60,22 @@ export const LoginScreenBaseTest = (): JSX.Element => (
                     // eslint-disable-next-line no-console
                     console.log('onContactSupport');
                 }}
-                errorDisplayConfig={{
-                    // LoginErrorDisplayConfig
-                    // mode?: 'dialog' | 'message-box' | 'both' | 'none';
-                    // dismissible?: boolean;
-                    // position?: 'top' | 'bottom';
-                    // fontColor?: string;
-                    // backgroundColor?: string;
-                    // dialogErrorConfig?: {
-                    // title?: string
-                    // content?: string | JSX.Element
-                    // acknowledgeButtonLabel?: string
-                    // onAcknowledgeError?: () => void
-                    // }
-                    mode: 'none',
-                    dismissible: true,
-                    position: 'top',
-                    // fontColor: 'white',
-                    // backgroundColor: 'red',
-                    error: 'Invalid username or password.',
-                }}
+                errorDisplayConfig={
+                    {
+                        // LoginErrorDisplayConfig
+                        // mode?: 'dialog' | 'message-box' | 'both' | 'none';
+                        // dismissible?: boolean;
+                        // position?: 'top' | 'bottom';
+                        // fontColor?: string;
+                        // backgroundColor?: string;
+                        // dialogErrorConfig?: {
+                        // title?: string
+                        // content?: string | JSX.Element
+                        // acknowledgeButtonLabel?: string
+                        // onAcknowledgeError?: () => void
+                        // }
+                    }
+                }
                 showCyberSecurityBadge={true}
                 projectImage={<img src={EatonLogo} alt="logo" style={{ maxHeight: 80 }} />}
                 // header={

--- a/login-workflow/example2/src/screens/new-architecture-test-screens/LoginScreenBase.tsx
+++ b/login-workflow/example2/src/screens/new-architecture-test-screens/LoginScreenBase.tsx
@@ -60,22 +60,6 @@ export const LoginScreenBaseTest = (): JSX.Element => (
                     // eslint-disable-next-line no-console
                     console.log('onContactSupport');
                 }}
-                errorDisplayConfig={
-                    {
-                        // LoginErrorDisplayConfig
-                        // mode?: 'dialog' | 'message-box' | 'both' | 'none';
-                        // dismissible?: boolean;
-                        // position?: 'top' | 'bottom';
-                        // fontColor?: string;
-                        // backgroundColor?: string;
-                        // dialogErrorConfig?: {
-                        // title?: string
-                        // content?: string | JSX.Element
-                        // acknowledgeButtonLabel?: string
-                        // onAcknowledgeError?: () => void
-                        // }
-                    }
-                }
                 showCyberSecurityBadge={true}
                 projectImage={<img src={EatonLogo} alt="logo" style={{ maxHeight: 80 }} />}
                 // header={

--- a/login-workflow/src/new-architecture/components/Error/ErrorManager.tsx
+++ b/login-workflow/src/new-architecture/components/Error/ErrorManager.tsx
@@ -51,7 +51,10 @@ const ErrorManager: React.FC<ErrorManagerProps> = (props): JSX.Element => {
         position,
     } = props;
 
-    return mode === 'dialog' ? (
+    //eslint-disable-next-line no-console
+    console.log('errorMessage:', errorMessage);
+
+    return mode === 'dialog' && errorMessage ? (
         <>
             {children}
             <BasicDialog
@@ -62,7 +65,7 @@ const ErrorManager: React.FC<ErrorManagerProps> = (props): JSX.Element => {
                 dismissButtonText={dismissButtonText}
             />
         </>
-    ) : mode === 'message-box' ? (
+    ) : mode === 'message-box' && errorMessage ? (
         <>
             {position === 'top' && (
                 <ErrorMessageBox
@@ -84,7 +87,7 @@ const ErrorManager: React.FC<ErrorManagerProps> = (props): JSX.Element => {
                 />
             )}
         </>
-    ) : mode === 'both' ? (
+    ) : mode === 'both' && errorMessage ? (
         <>
             {position === 'top' && (
                 <ErrorMessageBox

--- a/login-workflow/src/new-architecture/components/Error/ErrorManager.tsx
+++ b/login-workflow/src/new-architecture/components/Error/ErrorManager.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { BasicDialog } from '../Dialog/BasicDialog';
 import ErrorMessageBox from './ErrorMessageBox';
 
+export type AuthError = { cause: { title: string; errorMessage: string } };
+
 export type ErrorManagerProps = {
     mode?: 'dialog' | 'message-box' | 'both' | 'none';
     dismissible?: boolean;
@@ -13,7 +15,6 @@ export type ErrorManagerProps = {
     errorMessage?: string;
     onClose?: () => void;
     messageBoxSx?: SxProps;
-    open?: boolean;
     title?: string;
     children?: React.ReactNode;
 };
@@ -29,7 +30,6 @@ export type ErrorManagerProps = {
  * @param errorMessage error text to display
  * @param onClose function to call when the close/dismiss button is clicked
  * @param messageBoxSx sx styles passed to the underlying root(Box) component
- * @param open whether the dialog is open
  * @param title text to show in the title of the dialog
  *
  * @category Component
@@ -38,15 +38,14 @@ export type ErrorManagerProps = {
 const ErrorManager: React.FC<ErrorManagerProps> = (props): JSX.Element => {
     const {
         children,
-        mode,
-        dismissible,
+        mode = 'dialog',
+        dismissible = true,
         dismissButtonText,
         messageBoxFontColor,
         messageBoxBackgroundColor,
         errorMessage,
         onClose,
         messageBoxSx,
-        open,
         title,
         position,
     } = props;
@@ -54,67 +53,37 @@ const ErrorManager: React.FC<ErrorManagerProps> = (props): JSX.Element => {
     //eslint-disable-next-line no-console
     console.log('errorMessage:', errorMessage);
 
+    const ErrorDialogWithProps = (): JSX.Element => (
+        <BasicDialog
+            open={errorMessage.length > 0}
+            title={title}
+            body={errorMessage}
+            onClose={onClose}
+            dismissButtonText={dismissButtonText}
+        />
+    );
+
+    const ErrorMessageBoxWithProps = (): JSX.Element => (
+        <ErrorMessageBox
+            errorMessage={errorMessage}
+            dismissible={dismissible}
+            sx={messageBoxSx}
+            backgroundColor={messageBoxBackgroundColor}
+            fontColor={messageBoxFontColor}
+            onClose={onClose}
+        />
+    );
+
     return mode === 'dialog' && errorMessage ? (
         <>
             {children}
-            <BasicDialog
-                open={open}
-                title={title}
-                body={errorMessage}
-                onClose={onClose}
-                dismissButtonText={dismissButtonText}
-            />
+            <ErrorDialogWithProps />
         </>
     ) : mode === 'message-box' && errorMessage ? (
         <>
-            {position === 'top' && (
-                <ErrorMessageBox
-                    errorMessage={errorMessage}
-                    dismissible={dismissible}
-                    sx={messageBoxSx}
-                    backgroundColor={messageBoxBackgroundColor}
-                    fontColor={messageBoxFontColor}
-                />
-            )}
+            {position === 'top' && <ErrorMessageBoxWithProps />}
             {children}
-            {position === 'bottom' && (
-                <ErrorMessageBox
-                    errorMessage={errorMessage}
-                    dismissible={dismissible}
-                    sx={messageBoxSx}
-                    backgroundColor={messageBoxBackgroundColor}
-                    fontColor={messageBoxFontColor}
-                />
-            )}
-        </>
-    ) : mode === 'both' && errorMessage ? (
-        <>
-            {position === 'top' && (
-                <ErrorMessageBox
-                    errorMessage={errorMessage}
-                    dismissible={dismissible}
-                    sx={messageBoxSx}
-                    backgroundColor={messageBoxBackgroundColor}
-                    fontColor={messageBoxFontColor}
-                />
-            )}
-            {children}
-            {position === 'bottom' && (
-                <ErrorMessageBox
-                    errorMessage={errorMessage}
-                    dismissible={dismissible}
-                    sx={messageBoxSx}
-                    backgroundColor={messageBoxBackgroundColor}
-                    fontColor={messageBoxFontColor}
-                />
-            )}
-            <BasicDialog
-                open={open}
-                title={title}
-                body={errorMessage}
-                onClose={onClose}
-                dismissButtonText={dismissButtonText}
-            />
+            {position === 'bottom' && <ErrorMessageBoxWithProps />}
         </>
     ) : (
         <>{children}</>

--- a/login-workflow/src/new-architecture/components/Error/ErrorManager.tsx
+++ b/login-workflow/src/new-architecture/components/Error/ErrorManager.tsx
@@ -1,0 +1,120 @@
+import { SxProps } from '@mui/material/styles';
+import React from 'react';
+import { BasicDialog } from '../Dialog/BasicDialog';
+import ErrorMessageBox from './ErrorMessageBox';
+
+export type ErrorManagerProps = {
+    mode?: 'dialog' | 'message-box' | 'both' | 'none';
+    dismissible?: boolean;
+    position?: 'top' | 'bottom';
+    dismissButtonText?: string;
+    messageBoxFontColor?: string;
+    messageBoxBackgroundColor?: string;
+    errorMessage?: string;
+    onClose?: () => void;
+    messageBoxSx?: SxProps;
+    open?: boolean;
+    title?: string;
+    children?: React.ReactNode;
+};
+/**
+ * Component that manages the display of error messages. Can be configured to display a dialog, a message box, both, or neither.
+ *
+ * @param mode determines whether to display a dialog, a message box, both, or neither
+ * @param dismissible whether the message box can be dismissed
+ * @param dismissButtonText text to show in the close button
+ * @param position determines whether the message box should be displayed at the top or bottom of the screen
+ * @param messageBoxFontColor the font color of the text inside the message box
+ * @param messageBoxBackgroundColor the background color of the message box
+ * @param errorMessage error text to display
+ * @param onClose function to call when the close/dismiss button is clicked
+ * @param messageBoxSx sx styles passed to the underlying root(Box) component
+ * @param open whether the dialog is open
+ * @param title text to show in the title of the dialog
+ *
+ * @category Component
+ */
+
+const ErrorManager: React.FC<ErrorManagerProps> = (props): JSX.Element => {
+    const {
+        children,
+        mode,
+        dismissible,
+        dismissButtonText,
+        messageBoxFontColor,
+        messageBoxBackgroundColor,
+        errorMessage,
+        onClose,
+        messageBoxSx,
+        open,
+        title,
+        position,
+    } = props;
+
+    return mode === 'dialog' ? (
+        <>
+            {children}
+            <BasicDialog
+                open={open}
+                title={title}
+                body={errorMessage}
+                onClose={onClose}
+                dismissButtonText={dismissButtonText}
+            />
+        </>
+    ) : mode === 'message-box' ? (
+        <>
+            {position === 'top' && (
+                <ErrorMessageBox
+                    errorMessage={errorMessage}
+                    dismissible={dismissible}
+                    sx={messageBoxSx}
+                    backgroundColor={messageBoxBackgroundColor}
+                    fontColor={messageBoxFontColor}
+                />
+            )}
+            {children}
+            {position === 'bottom' && (
+                <ErrorMessageBox
+                    errorMessage={errorMessage}
+                    dismissible={dismissible}
+                    sx={messageBoxSx}
+                    backgroundColor={messageBoxBackgroundColor}
+                    fontColor={messageBoxFontColor}
+                />
+            )}
+        </>
+    ) : mode === 'both' ? (
+        <>
+            {position === 'top' && (
+                <ErrorMessageBox
+                    errorMessage={errorMessage}
+                    dismissible={dismissible}
+                    sx={messageBoxSx}
+                    backgroundColor={messageBoxBackgroundColor}
+                    fontColor={messageBoxFontColor}
+                />
+            )}
+            {children}
+            {position === 'bottom' && (
+                <ErrorMessageBox
+                    errorMessage={errorMessage}
+                    dismissible={dismissible}
+                    sx={messageBoxSx}
+                    backgroundColor={messageBoxBackgroundColor}
+                    fontColor={messageBoxFontColor}
+                />
+            )}
+            <BasicDialog
+                open={open}
+                title={title}
+                body={errorMessage}
+                onClose={onClose}
+                dismissButtonText={dismissButtonText}
+            />
+        </>
+    ) : (
+        <>{children}</>
+    );
+};
+export default ErrorManager;

--- a/login-workflow/src/new-architecture/components/Error/ErrorMessageBox.tsx
+++ b/login-workflow/src/new-architecture/components/Error/ErrorMessageBox.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Close from '@mui/icons-material/Close';
+import { SxProps } from '@mui/material/styles';
+import Typography from '@mui/material/Typography';
+import * as Colors from '@brightlayer-ui/colors';
+export type ErrorMessageBoxProps = {
+    errorMessage: string;
+    backgroundColor?: string;
+    dismissible?: boolean;
+    fontColor?: string;
+    onClose?: () => void;
+    sx?: SxProps;
+};
+/**
+ * Component that renders a basic message box with an error message and a configurable dismiss button.
+ *
+ * @param errorMessage text to show in the title
+ * @param backgroundColor the background color of the message box
+ * @param dismissible whether the message box can be dismissed
+ * @param fontColor the font color of the text inside the message box
+ * @param onClose function to call when the close button is clicked
+ * @param sx sx styles passed to the underlying root(Box) component
+ *
+ * @category Component
+ */
+const ErrorMessageBox = (props: ErrorMessageBoxProps): JSX.Element => {
+    const { errorMessage, backgroundColor, dismissible = true, fontColor, onClose = (): void => {}, sx } = props;
+    return (
+        <Box
+            sx={[
+                {
+                    width: '100%',
+                    backgroundColor: backgroundColor || 'error.main',
+                    borderRadius: 4,
+                    p: 2,
+                    color: fontColor || Colors.white[50],
+                    mb: 2,
+                },
+                ...(Array.isArray(sx) ? sx : [sx]),
+            ]}
+        >
+            {dismissible !== false && (
+                <Close
+                    sx={{
+                        '&:hover': {
+                            cursor: 'pointer',
+                        },
+                        float: 'right',
+                    }}
+                    onClick={(): void => {
+                        onClose();
+                    }}
+                />
+            )}
+            <Typography variant="body2">{errorMessage}</Typography>
+        </Box>
+    );
+};
+export default ErrorMessageBox;

--- a/login-workflow/src/new-architecture/components/Error/index.ts
+++ b/login-workflow/src/new-architecture/components/Error/index.ts
@@ -1,0 +1,2 @@
+export * from './ErrorManager';
+export * from './ErrorMessageBox';

--- a/login-workflow/src/new-architecture/contexts/AuthContext/provider.tsx
+++ b/login-workflow/src/new-architecture/contexts/AuthContext/provider.tsx
@@ -8,10 +8,11 @@ import { AuthContextProviderProps } from './types';
 import { AuthContext } from './context';
 import { I18nextProvider } from 'react-i18next';
 import { i18nAuthInstance } from './i18nAuthInstance';
+import { ErrorContext } from '../ErrorContext';
 
 export const AuthContextProvider: React.FC<React.PropsWithChildren<AuthContextProviderProps>> = (props) => {
     const { children, ...authContextProps } = props;
-    const { language, i18n = i18nAuthInstance } = props;
+    const { language, i18n = i18nAuthInstance, errorConfig } = props;
 
     useEffect(() => {
         void i18n.changeLanguage(language);
@@ -19,7 +20,11 @@ export const AuthContextProvider: React.FC<React.PropsWithChildren<AuthContextPr
 
     return (
         <I18nextProvider i18n={i18n}>
-            <AuthContext.Provider value={authContextProps}>{children}</AuthContext.Provider>
+            <AuthContext.Provider value={authContextProps}>
+                <ErrorContext.Provider value={errorConfig}>
+                    {children}
+                </ErrorContext.Provider>
+            </AuthContext.Provider>
         </I18nextProvider>
     );
 };

--- a/login-workflow/src/new-architecture/contexts/AuthContext/provider.tsx
+++ b/login-workflow/src/new-architecture/contexts/AuthContext/provider.tsx
@@ -21,9 +21,7 @@ export const AuthContextProvider: React.FC<React.PropsWithChildren<AuthContextPr
     return (
         <I18nextProvider i18n={i18n}>
             <AuthContext.Provider value={authContextProps}>
-                <ErrorContext.Provider value={errorConfig}>
-                    {children}
-                </ErrorContext.Provider>
+                <ErrorContext.Provider value={errorConfig}>{children}</ErrorContext.Provider>
             </AuthContext.Provider>
         </I18nextProvider>
     );

--- a/login-workflow/src/new-architecture/contexts/AuthContext/types.ts
+++ b/login-workflow/src/new-architecture/contexts/AuthContext/types.ts
@@ -5,6 +5,7 @@
 
 import { i18n } from 'i18next';
 import { RouteConfig } from '../../../routing/AuthNavigationContainer';
+import { ErrorContextProviderProps } from '../ErrorContext/types';
 
 export type AuthContextProviderProps = {
     actions: () => AuthUIActions;
@@ -22,6 +23,7 @@ export type AuthContextProviderProps = {
          */
         rememberMe?: boolean;
     };
+    errorConfig?: ErrorContextProviderProps;
 };
 
 export type AuthUIActions = {

--- a/login-workflow/src/new-architecture/contexts/ErrorContext/context.ts
+++ b/login-workflow/src/new-architecture/contexts/ErrorContext/context.ts
@@ -1,0 +1,8 @@
+/**
+ * @packageDocumentation
+ * @module ErrorContext
+ */
+import { createContext } from 'react';
+import { ErrorContextProviderProps } from './types';
+
+export const ErrorContext = createContext<ErrorContextProviderProps | null>(null);

--- a/login-workflow/src/new-architecture/contexts/ErrorContext/index.ts
+++ b/login-workflow/src/new-architecture/contexts/ErrorContext/index.ts
@@ -1,0 +1,23 @@
+import { useContext } from 'react';
+import { ErrorContext } from './context';
+import { ErrorContextProvider } from './provider';
+import { ErrorContextProviderProps } from './types';
+
+/**
+ * Hook to get top level data in authentication workflow
+ *
+ * @category Hooks
+ * @private
+ * @internal
+ */
+export const useErrorContext = (): ErrorContextProviderProps => {
+    const context = useContext(ErrorContext);
+    if (context === null) {
+        throw new Error('useErrorContext must be used within ErrorContextProvider');
+    }
+    return context;
+};
+
+export type { ErrorContextProviderProps };
+
+export { ErrorContext, ErrorContextProvider };

--- a/login-workflow/src/new-architecture/contexts/ErrorContext/provider.tsx
+++ b/login-workflow/src/new-architecture/contexts/ErrorContext/provider.tsx
@@ -1,0 +1,14 @@
+/**
+ * @packageDocumentation
+ * @module ErrorContextProvider
+ */
+
+import React from 'react';
+import { ErrorContextProviderProps } from './types';
+import { ErrorContext } from './context';
+
+export const ErrorContextProvider: React.FC<React.PropsWithChildren<ErrorContextProviderProps>> = (props) => {
+    const { children, ...ErrorContextProps } = props;
+
+    return <ErrorContext.Provider value={ErrorContextProps}>{children}</ErrorContext.Provider>;
+};

--- a/login-workflow/src/new-architecture/contexts/ErrorContext/types.ts
+++ b/login-workflow/src/new-architecture/contexts/ErrorContext/types.ts
@@ -1,0 +1,8 @@
+/**
+ * @packageDocumentation
+ * @module ErrorContext
+ */
+
+import { ErrorManagerProps } from '../../components/Error/ErrorManager';
+
+export type ErrorContextProviderProps = ErrorManagerProps;

--- a/login-workflow/src/new-architecture/contexts/RegistrationContext/provider.tsx
+++ b/login-workflow/src/new-architecture/contexts/RegistrationContext/provider.tsx
@@ -23,9 +23,7 @@ export const RegistrationContextProvider: React.FC<React.PropsWithChildren<Regis
     return (
         <I18nextProvider i18n={i18n}>
             <RegistrationContext.Provider value={registrationContextProps}>
-                <ErrorContext.Provider value={errorConfig}>
-                    {children}
-                </ErrorContext.Provider>
+                <ErrorContext.Provider value={errorConfig}>{children}</ErrorContext.Provider>
             </RegistrationContext.Provider>
         </I18nextProvider>
     );

--- a/login-workflow/src/new-architecture/contexts/RegistrationContext/provider.tsx
+++ b/login-workflow/src/new-architecture/contexts/RegistrationContext/provider.tsx
@@ -8,12 +8,13 @@ import { RegistrationContextProviderProps } from './types';
 import { RegistrationContext } from './context';
 import { I18nextProvider } from 'react-i18next';
 import { i18nRegistrationInstance } from './i18nRegistrationInstance';
+import { ErrorContext } from '../ErrorContext';
 
 export const RegistrationContextProvider: React.FC<React.PropsWithChildren<RegistrationContextProviderProps>> = (
     props
 ) => {
     const { children, ...registrationContextProps } = props;
-    const { language, i18n = i18nRegistrationInstance } = props;
+    const { language, i18n = i18nRegistrationInstance, errorConfig } = props;
 
     useEffect(() => {
         void i18n.changeLanguage(language);
@@ -21,7 +22,11 @@ export const RegistrationContextProvider: React.FC<React.PropsWithChildren<Regis
 
     return (
         <I18nextProvider i18n={i18n}>
-            <RegistrationContext.Provider value={registrationContextProps}>{children}</RegistrationContext.Provider>
+            <RegistrationContext.Provider value={registrationContextProps}>
+                <ErrorContext.Provider value={errorConfig}>
+                    {children}
+                </ErrorContext.Provider>
+            </RegistrationContext.Provider>
         </I18nextProvider>
     );
 };

--- a/login-workflow/src/new-architecture/contexts/RegistrationContext/types.ts
+++ b/login-workflow/src/new-architecture/contexts/RegistrationContext/types.ts
@@ -1,4 +1,5 @@
 import { i18n } from 'i18next';
+import { ErrorContextProviderProps } from '../ErrorContext';
 
 // @TODO: this will need migrated to AuthContext types when that is ready
 export type AccountDetails = {
@@ -38,4 +39,5 @@ export type RegistrationContextProviderProps = {
     navigate: (url: string) => void;
     routeConfig: RouteConfig;
     i18n?: i18n; // add languages / override strings in bulk
+    errorConfig?: ErrorContextProviderProps;
 };

--- a/login-workflow/src/new-architecture/screens/AccountDetailsScreen/AccountDetailsScreenBase.tsx
+++ b/login-workflow/src/new-architecture/screens/AccountDetailsScreen/AccountDetailsScreenBase.tsx
@@ -8,6 +8,7 @@ import {
     WorkflowCardInstructions,
 } from '../../components/WorkflowCard';
 import { AccountDetailsScreenProps } from './types';
+import ErrorManager from '../../components/Error/ErrorManager';
 
 export const AccountDetailsScreenBase: React.FC<AccountDetailsScreenProps> = (props) => {
     const {
@@ -19,6 +20,7 @@ export const AccountDetailsScreenBase: React.FC<AccountDetailsScreenProps> = (pr
         initialLastName,
         lastNameValidator,
         lastNameTextFieldProps,
+        errorDisplayConfig,
     } = props;
 
     const cardBaseProps = props.WorkflowCardBaseProps || {};
@@ -115,42 +117,44 @@ export const AccountDetailsScreenBase: React.FC<AccountDetailsScreenProps> = (pr
             <WorkflowCardHeader {...headerProps} />
             <WorkflowCardBody>
                 <WorkflowCardInstructions {...instructionsProps} divider />
-                <TextField
-                    id="first"
-                    fullWidth
-                    variant="filled"
-                    {...firstNameTextFieldProps}
-                    inputRef={firstNameRef}
-                    label={firstNameLabel}
-                    value={firstNameInput}
-                    onChange={(e): void => onFirstNameChange(e.target.value)}
-                    onKeyUp={(e): void => {
-                        if (e.key === 'Enter' && lastNameRef.current) lastNameRef.current.focus();
-                    }}
-                    error={showFirstNameError}
-                    helperText={firstNameError}
-                    sx={{
-                        mb: { md: 0, sm: 1, xs: 4 },
-                    }}
-                />
-                <TextField
-                    id="last"
-                    fullWidth
-                    variant="filled"
-                    sx={{
-                        mt: { md: 4, sm: 3 },
-                    }}
-                    {...lastNameTextFieldProps}
-                    inputRef={lastNameRef}
-                    label={lastNameLabel}
-                    value={lastNameInput}
-                    onChange={(e): void => onLastNameChange(e.target.value)}
-                    onKeyUp={(e): void => {
-                        if (e.key === 'Enter' && isFormValid && actionsProps.canGoNext) actionsProps.onNext();
-                    }}
-                    error={showLastNameError}
-                    helperText={lastNameError}
-                />
+                <ErrorManager {...errorDisplayConfig}>
+                    <TextField
+                        id="first"
+                        fullWidth
+                        variant="filled"
+                        {...firstNameTextFieldProps}
+                        inputRef={firstNameRef}
+                        label={firstNameLabel}
+                        value={firstNameInput}
+                        onChange={(e): void => onFirstNameChange(e.target.value)}
+                        onKeyUp={(e): void => {
+                            if (e.key === 'Enter' && lastNameRef.current) lastNameRef.current.focus();
+                        }}
+                        error={showFirstNameError}
+                        helperText={firstNameError}
+                        sx={{
+                            mb: { md: 0, sm: 1, xs: 4 },
+                        }}
+                    />
+                    <TextField
+                        id="last"
+                        fullWidth
+                        variant="filled"
+                        sx={{
+                            mt: { md: 4, sm: 3 },
+                        }}
+                        {...lastNameTextFieldProps}
+                        inputRef={lastNameRef}
+                        label={lastNameLabel}
+                        value={lastNameInput}
+                        onChange={(e): void => onLastNameChange(e.target.value)}
+                        onKeyUp={(e): void => {
+                            if (e.key === 'Enter' && isFormValid && actionsProps.canGoNext) actionsProps.onNext();
+                        }}
+                        error={showLastNameError}
+                        helperText={lastNameError}
+                    />
+                </ErrorManager>
             </WorkflowCardBody>
             <WorkflowCardActions
                 {...actionsProps}

--- a/login-workflow/src/new-architecture/screens/AccountDetailsScreen/types.ts
+++ b/login-workflow/src/new-architecture/screens/AccountDetailsScreen/types.ts
@@ -1,6 +1,7 @@
 import { SxProps } from '@mui/material';
 import { WorkflowCardProps } from '../../components/WorkflowCard/WorkflowCard.types';
 import { MinifiedTextFieldProps } from '../../types';
+import { ErrorManagerProps } from '../../components/Error';
 
 export type AccountDetailsScreenProps = WorkflowCardProps & {
     // used to test the input for valid formatting
@@ -15,5 +16,6 @@ export type AccountDetailsScreenProps = WorkflowCardProps & {
     lastNameValidator?: (lastName: string) => boolean | string;
     lastNameTextFieldProps?: MinifiedTextFieldProps;
 
+    errorDisplayConfig?: ErrorManagerProps;
     sx?: SxProps;
 };

--- a/login-workflow/src/new-architecture/screens/CreateAccountScreen/CreateAccountScreen.tsx
+++ b/login-workflow/src/new-architecture/screens/CreateAccountScreen/CreateAccountScreen.tsx
@@ -4,6 +4,8 @@ import { CreateAccountScreenBase } from './CreateAccountScreenBase';
 import { useLanguageLocale } from '../../hooks';
 import { useRegistrationContext } from '../../contexts/RegistrationContext/context';
 import { useRegistrationWorkflowContext } from '../../contexts';
+import { AuthError } from '../../components/Error';
+import { useErrorContext } from '../../contexts/ErrorContext';
 
 /**
  * Component that renders a screen for the user to enter their email address to start the
@@ -22,9 +24,11 @@ export const CreateAccountScreen: React.FC<CreateAccountScreenProps> = (props) =
     const { t } = useLanguageLocale();
     const { actions } = useRegistrationContext();
     const regWorkflow = useRegistrationWorkflowContext();
+    const errorConfig = useErrorContext();
     const { nextScreen, previousScreen, screenData } = regWorkflow;
     const [emailInputValue, setEmailInputValue] = useState(screenData.CreateAccount.emailAddress);
     const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<AuthError>({ cause: { title: '', errorMessage: '' } });
 
     const onNext = useCallback(async () => {
         try {
@@ -34,8 +38,13 @@ export const CreateAccountScreen: React.FC<CreateAccountScreenProps> = (props) =
                 screenId: 'CreateAccount',
                 values: { emailAddress: emailInputValue },
             });
-        } catch {
-            console.error('Error while updating create account!');
+        } catch (_error) {
+            setError({
+                cause: {
+                    title: (_error as AuthError).cause.title,
+                    errorMessage: (_error as AuthError).cause.errorMessage,
+                },
+            });
         }
         setIsLoading(false);
     }, [emailInputValue, nextScreen, actions]);
@@ -60,6 +69,7 @@ export const CreateAccountScreen: React.FC<CreateAccountScreenProps> = (props) =
             return true;
         },
         emailTextFieldProps,
+        errorDisplayConfig = errorConfig,
     } = props;
 
     const workflowCardBaseProps = {
@@ -110,6 +120,14 @@ export const CreateAccountScreen: React.FC<CreateAccountScreenProps> = (props) =
             emailTextFieldProps={{ ...emailTextFieldProps, onChange: onEmailInputValueChange }}
             emailValidator={emailValidator}
             WorkflowCardActionsProps={workflowCardActionsProps}
+            errorDisplayConfig={{
+                ...errorDisplayConfig,
+                title: error.cause.title,
+                errorMessage: error.cause.errorMessage,
+                onClose: (): void => {
+                    setError({ cause: { title: '', errorMessage: '' } });
+                },
+            }}
         />
     );
 };

--- a/login-workflow/src/new-architecture/screens/CreateAccountScreen/CreateAccountScreenBase.tsx
+++ b/login-workflow/src/new-architecture/screens/CreateAccountScreen/CreateAccountScreenBase.tsx
@@ -6,6 +6,7 @@ import { WorkflowCardBody } from '../../components/WorkflowCard/WorkflowCardBody
 import { WorkflowCardHeader } from '../../components/WorkflowCard/WorkflowCardHeader';
 import { WorkflowCardInstructions } from '../../components/WorkflowCard/WorkflowCardInstructions';
 import TextField from '@mui/material/TextField';
+import ErrorManager from '../../components/Error/ErrorManager';
 
 /**
  * Component that renders a screen for the user to enter their email address to start the
@@ -29,6 +30,7 @@ export const CreateAccountScreenBase: React.FC<
         initialValue,
         emailTextFieldProps,
         inputRef,
+        errorDisplayConfig,
     } = props;
 
     const cardBaseProps = props.WorkflowCardBaseProps || {};
@@ -57,31 +59,33 @@ export const CreateAccountScreenBase: React.FC<
             <WorkflowCardHeader {...headerProps}></WorkflowCardHeader>
             <WorkflowCardBody>
                 <WorkflowCardInstructions {...instructionsProps} divider />
-                <TextField
-                    ref={inputRef}
-                    type={'email'}
-                    label={emailLabel}
-                    fullWidth
-                    value={emailInput}
-                    variant="filled"
-                    error={shouldValidateEmail && !isEmailValid}
-                    helperText={shouldValidateEmail && emailError}
-                    {...emailTextFieldProps}
-                    onChange={(e): void => {
-                        // eslint-disable-next-line no-unused-expressions
-                        emailTextFieldProps?.onChange && emailTextFieldProps.onChange(e);
-                        handleEmailInputChange(e.target.value);
-                    }}
-                    onKeyUp={(e): void => {
-                        if (e.key === 'Enter' && emailInput.length > 0 && isEmailValid && actionsProps.canGoNext)
-                            actionsProps?.onNext?.();
-                    }}
-                    onBlur={(e): void => {
-                        // eslint-disable-next-line no-unused-expressions
-                        emailTextFieldProps?.onBlur && emailTextFieldProps.onBlur(e);
-                        setShouldValidateEmail(true);
-                    }}
-                />
+                <ErrorManager {...errorDisplayConfig}>
+                    <TextField
+                        ref={inputRef}
+                        type={'email'}
+                        label={emailLabel}
+                        fullWidth
+                        value={emailInput}
+                        variant="filled"
+                        error={shouldValidateEmail && !isEmailValid}
+                        helperText={shouldValidateEmail && emailError}
+                        {...emailTextFieldProps}
+                        onChange={(e): void => {
+                            // eslint-disable-next-line no-unused-expressions
+                            emailTextFieldProps?.onChange && emailTextFieldProps.onChange(e);
+                            handleEmailInputChange(e.target.value);
+                        }}
+                        onKeyUp={(e): void => {
+                            if (e.key === 'Enter' && emailInput.length > 0 && isEmailValid && actionsProps.canGoNext)
+                                actionsProps?.onNext?.();
+                        }}
+                        onBlur={(e): void => {
+                            // eslint-disable-next-line no-unused-expressions
+                            emailTextFieldProps?.onBlur && emailTextFieldProps.onBlur(e);
+                            setShouldValidateEmail(true);
+                        }}
+                    />
+                </ErrorManager>
             </WorkflowCardBody>
             <WorkflowCardActions
                 {...actionsProps}

--- a/login-workflow/src/new-architecture/screens/CreateAccountScreen/types.ts
+++ b/login-workflow/src/new-architecture/screens/CreateAccountScreen/types.ts
@@ -1,5 +1,6 @@
 import { TextFieldProps } from '@mui/material';
 import { WorkflowCardProps } from '../../components/WorkflowCard/WorkflowCard.types';
+import { ErrorManagerProps } from '../../components/Error';
 
 export type CreateAccountScreenProps = WorkflowCardProps & {
     // label for the textfield
@@ -13,4 +14,6 @@ export type CreateAccountScreenProps = WorkflowCardProps & {
 
     // props to pass to the email text field
     emailTextFieldProps?: TextFieldProps;
+
+    errorDisplayConfig?: ErrorManagerProps;
 };

--- a/login-workflow/src/new-architecture/screens/CreatePasswordScreen/CreatePasswordScreenBase.tsx
+++ b/login-workflow/src/new-architecture/screens/CreatePasswordScreen/CreatePasswordScreenBase.tsx
@@ -8,6 +8,7 @@ import {
     WorkflowCardInstructions,
 } from '../../components';
 import { SetPassword } from '../../components/SetPassword';
+import ErrorManager from '../../components/Error/ErrorManager';
 
 export const CreatePasswordScreenBase: React.FC<React.PropsWithChildren<CreatePasswordScreenProps>> = (props) => {
     const cardBaseProps = props.WorkflowCardBaseProps || {};
@@ -15,13 +16,16 @@ export const CreatePasswordScreenBase: React.FC<React.PropsWithChildren<CreatePa
     const instructionsProps = props.WorkflowCardInstructionProps || {};
     const actionsProps = props.WorkflowCardActionsProps || {};
     const passwordProps = props.PasswordProps || { onPasswordChange: () => ({}) };
+    const { errorDisplayConfig } = props;
 
     return (
         <WorkflowCard {...cardBaseProps}>
             <WorkflowCardHeader {...headerProps} />
             <WorkflowCardBody>
                 <WorkflowCardInstructions {...instructionsProps} divider />
-                <SetPassword {...passwordProps} />
+                <ErrorManager {...errorDisplayConfig}>
+                    <SetPassword {...passwordProps} />
+                </ErrorManager>
             </WorkflowCardBody>
             <WorkflowCardActions {...actionsProps} divider />
         </WorkflowCard>

--- a/login-workflow/src/new-architecture/screens/CreatePasswordScreen/types.ts
+++ b/login-workflow/src/new-architecture/screens/CreatePasswordScreen/types.ts
@@ -2,4 +2,7 @@ import { SetPasswordProps } from '../../components';
 import { ErrorManagerProps } from '../../components/Error';
 import { WorkflowCardProps } from '../../components/WorkflowCard/WorkflowCard.types';
 
-export type CreatePasswordScreenProps = WorkflowCardProps & { PasswordProps?: SetPasswordProps, errorDisplayConfig?: ErrorManagerProps };
+export type CreatePasswordScreenProps = WorkflowCardProps & {
+    PasswordProps?: SetPasswordProps;
+    errorDisplayConfig?: ErrorManagerProps;
+};

--- a/login-workflow/src/new-architecture/screens/CreatePasswordScreen/types.ts
+++ b/login-workflow/src/new-architecture/screens/CreatePasswordScreen/types.ts
@@ -1,4 +1,5 @@
 import { SetPasswordProps } from '../../components';
+import { ErrorManagerProps } from '../../components/Error';
 import { WorkflowCardProps } from '../../components/WorkflowCard/WorkflowCard.types';
 
-export type CreatePasswordScreenProps = WorkflowCardProps & { PasswordProps?: SetPasswordProps };
+export type CreatePasswordScreenProps = WorkflowCardProps & { PasswordProps?: SetPasswordProps, errorDisplayConfig?: ErrorManagerProps };

--- a/login-workflow/src/new-architecture/screens/LoginScreen/LoginScreen.tsx
+++ b/login-workflow/src/new-architecture/screens/LoginScreen/LoginScreen.tsx
@@ -3,6 +3,7 @@ import { LoginScreenProps } from './types';
 import { LoginScreenBase } from './LoginScreenBase';
 import { useLanguageLocale } from '../../hooks';
 import { useAuthContext } from '../../contexts';
+import { useErrorContext } from '../../contexts/ErrorContext';
 
 const EMAIL_REGEX = /^[A-Z0-9._%+'-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
 
@@ -46,6 +47,7 @@ type LoginScreenPropsPublic = Omit<LoginScreenProps, 'passwordValidator'> & { pa
 export const LoginScreen: React.FC<React.PropsWithChildren<LoginScreenPropsPublic>> = (props) => {
     const { t } = useLanguageLocale();
     const auth = useAuthContext();
+    const errorConfig = useErrorContext();
     const { actions, navigate, routeConfig, rememberMeDetails } = auth;
 
     useEffect(() => {
@@ -83,7 +85,7 @@ export const LoginScreen: React.FC<React.PropsWithChildren<LoginScreenPropsPubli
         showContactSupport = true,
         contactSupportLabel = t('bluiCommon:MESSAGES.CONTACT'),
         onContactSupport = (): void => navigate(routeConfig.SUPPORT),
-        errorDisplayConfig,
+        errorDisplayConfig = errorConfig,
         showCyberSecurityBadge = true,
         projectImage,
         header,

--- a/login-workflow/src/new-architecture/screens/LoginScreen/LoginScreen.tsx
+++ b/login-workflow/src/new-architecture/screens/LoginScreen/LoginScreen.tsx
@@ -4,6 +4,7 @@ import { LoginScreenBase } from './LoginScreenBase';
 import { useLanguageLocale } from '../../hooks';
 import { useAuthContext } from '../../contexts';
 import { useErrorContext } from '../../contexts/ErrorContext';
+import { AuthError } from '../../components/Error';
 
 const EMAIL_REGEX = /^[A-Z0-9._%+'-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
 
@@ -43,7 +44,6 @@ const EMAIL_REGEX = /^[A-Z0-9._%+'-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i;
  */
 
 type LoginScreenPropsPublic = Omit<LoginScreenProps, 'passwordValidator'> & { passwordRequiredValidatorText?: string };
-type AuthError = { cause: { title: string; errorMessage: string } };
 
 export const LoginScreen: React.FC<React.PropsWithChildren<LoginScreenPropsPublic>> = (props) => {
     const { t } = useLanguageLocale();
@@ -118,11 +118,7 @@ export const LoginScreen: React.FC<React.PropsWithChildren<LoginScreenPropsPubli
                 try {
                     await actions().logIn(username, password, rememberMe);
                     await props.onLogin?.(username, password, rememberMe);
-                    // eslint-disable-next-line no-console
-                    console.log('login success');
                 } catch (_error) {
-                    // eslint-disable-next-line no-console
-                    console.log('error from LoginScreen:', _error);
                     setError({
                         cause: {
                             title: (_error as AuthError).cause.title,
@@ -145,6 +141,9 @@ export const LoginScreen: React.FC<React.PropsWithChildren<LoginScreenPropsPubli
                 ...errorDisplayConfig,
                 title: error.cause.title,
                 errorMessage: error.cause.errorMessage,
+                onClose: (): void => {
+                    setError({ cause: { title: '', errorMessage: '' } });
+                },
             }}
             showCyberSecurityBadge={showCyberSecurityBadge}
             projectImage={projectImage}

--- a/login-workflow/src/new-architecture/screens/LoginScreen/LoginScreenBase.tsx
+++ b/login-workflow/src/new-architecture/screens/LoginScreen/LoginScreenBase.tsx
@@ -10,11 +10,10 @@ import { PasswordTextField } from '../../components';
 import Button from '@mui/material/Button';
 import { useTheme } from '@mui/material/styles';
 import Checkbox from '@mui/material/Checkbox';
-import Close from '@mui/icons-material/Close';
-import * as Colors from '@brightlayer-ui/colors';
 import { HELPER_TEXT_HEIGHT } from '../../utils/constants';
 import { LoginScreenClassKey, getLoginScreenUtilityClass } from './utilityClasses';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
+import ErrorManager from '../../components/Error/ErrorManager';
 
 /**
  * Component that renders a login screen that prompts a user to enter a username and password to login.
@@ -125,6 +124,9 @@ export const LoginScreenBase: React.FC<React.PropsWithChildren<LoginScreenProps>
         footer,
     } = props;
 
+    // eslint-disable-next-line no-console
+    console.log('errorDisplayconfig from login base', errorDisplayConfig);
+
     const theme = useTheme();
     const defaultClasses = useUtilityClasses(props);
 
@@ -143,8 +145,8 @@ export const LoginScreenBase: React.FC<React.PropsWithChildren<LoginScreenProps>
     const [usernameError, setUsernameError] = useState(isUsernameValid === true ? '' : isUsernameValid);
     const [passwordError, setPasswordError] = useState(isPasswordValid === true ? '' : isPasswordValid);
 
-    const [hasAcknowledgedError, setHasAcknowledgedError] = React.useState(false);
-    const [showErrorMessageBox, setShowErrorMessageBox] = React.useState(true);
+    // const [hasAcknowledgedError, setHasAcknowledgedError] = React.useState(false);
+    // const [showErrorMessageBox, setShowErrorMessageBox] = React.useState(true);
     // const [debugMode, setDebugMode] = React.useState(false);
 
     const handleUsernameInputChange = useCallback(
@@ -192,8 +194,6 @@ export const LoginScreenBase: React.FC<React.PropsWithChildren<LoginScreenProps>
         }
     };
 
-    const shouldValidate = (): boolean => shouldValidateUsername || shouldValidatePassword;
-
     const isFormValid = (): boolean =>
         typeof isUsernameValid === 'boolean' &&
         isUsernameValid &&
@@ -201,86 +201,11 @@ export const LoginScreenBase: React.FC<React.PropsWithChildren<LoginScreenProps>
         isPasswordValid;
 
     const handleLoginSubmit = (e: React.KeyboardEvent<HTMLDivElement>): void => {
-        setHasAcknowledgedError(false);
+        // setHasAcknowledgedError(false);
         if (e.key === 'Enter' && isFormValid()) {
             void handleLogin();
         }
     };
-
-    const errorDisplayConfigProps = {
-        ...errorDisplayConfig,
-        usernameError,
-        passwordError,
-        shouldValidate,
-        isFormValid,
-    };
-
-    // const ErrorDialog = (): JSX.Element => {
-    //     const dialogTitle = errorDisplayConfigProps?.dialogErrorConfig?.title || 'Error!';
-
-    //     const dialogBody =
-    //         errorDisplayConfigProps?.dialogErrorConfig?.content ||
-    //         (typeof usernameError === 'string' && usernameError) ||
-    //         (typeof passwordError === 'string' && passwordError) ||
-    //         'An error has occurred.';
-
-    //     const isOpen =
-    //         !hasAcknowledgedError &&
-    //         ((typeof usernameError === 'boolean' && !isUsernameValid) ||
-    //             (typeof passwordError === 'boolean' && !isPasswordValid));
-
-    //     return (
-    //         <BasicDialog
-    //             title={dialogTitle}
-    //             body={dialogBody}
-    //             open={isOpen}
-    //             onClose={(): void => {
-    //                 errorDisplayConfig?.dialogErrorConfig?.onAcknowledgeError();
-    //                 setHasAcknowledgedError(true);
-    //             }}
-    //         />
-    //     );
-    // };
-
-    const errorMessageBox: JSX.Element =
-        (errorDisplayConfig?.mode === 'message-box' || errorDisplayConfig?.mode === 'both') && !hasAcknowledgedError ? (
-            <Box
-                sx={{
-                    width: '100%',
-                    backgroundColor: errorDisplayConfigProps?.backgroundColor || 'error.main',
-                    borderRadius: 4,
-                    p: 2,
-                    color: errorDisplayConfigProps?.fontColor || Colors.white[50],
-                    mb: 2,
-                    mt: errorDisplayConfigProps?.position !== 'bottom' ? 0 : -1,
-                }}
-            >
-                {errorDisplayConfigProps?.dismissible !== false && (
-                    <Close
-                        sx={{
-                            '&:hover': {
-                                cursor: 'pointer',
-                            },
-                            float: 'right',
-                        }}
-                        onClick={(): void => {
-                            setShowErrorMessageBox(false);
-                        }}
-                    />
-                )}
-                {errorDisplayConfigProps?.error && typeof errorDisplayConfigProps?.error === 'string' && (
-                    <Typography variant="body2">{errorDisplayConfigProps.error}</Typography>
-                )}
-                {errorDisplayConfigProps?.error &&
-                    typeof errorDisplayConfigProps?.error === 'boolean' &&
-                    !isUsernameValid && <Typography variant="body2">{usernameError}</Typography>}
-                {errorDisplayConfigProps?.error &&
-                    typeof errorDisplayConfigProps?.error === 'boolean' &&
-                    !isPasswordValid && <Typography variant="body2">{passwordError}</Typography>}
-            </Box>
-        ) : (
-            <></>
-        );
 
     return (
         <>
@@ -294,111 +219,112 @@ export const LoginScreenBase: React.FC<React.PropsWithChildren<LoginScreenProps>
                     >
                         {projectImage}
                     </Box>
-                    {showErrorMessageBox && errorDisplayConfig?.position === 'top' && errorMessageBox}
-                    <Box
-                        sx={{
-                            display: 'flex',
-                            flexDirection: 'column',
-                            justifyContent: 'center',
-                            alignItems: 'center',
-                            width: '100%',
-                        }}
-                        className={defaultClasses.inputFieldsWrapper}
-                        data-testid={defaultClasses.inputFieldsWrapper}
-                    >
+
+                    <ErrorManager {...errorDisplayConfig}>
                         <Box
                             sx={{
+                                display: 'flex',
+                                flexDirection: 'column',
+                                justifyContent: 'center',
+                                alignItems: 'center',
                                 width: '100%',
-                                mb:
-                                    username.length > 0 && !isUsernameValid && shouldValidateUsername
-                                        ? 4
-                                        : `${(parseInt(theme.spacing(4)) + HELPER_TEXT_HEIGHT).toString()}px`,
-                                [theme.breakpoints.down('sm')]: {
+                            }}
+                            className={defaultClasses.inputFieldsWrapper}
+                            data-testid={defaultClasses.inputFieldsWrapper}
+                        >
+                            <Box
+                                sx={{
+                                    width: '100%',
                                     mb:
                                         username.length > 0 && !isUsernameValid && shouldValidateUsername
-                                            ? 3
-                                            : `${(parseInt(theme.spacing(3)) + HELPER_TEXT_HEIGHT).toString()}px`,
-                                },
-                            }}
-                        >
-                            <TextField
-                                fullWidth
-                                id="username"
-                                className={defaultClasses.usernameTextField}
-                                data-testid={defaultClasses.usernameTextField}
-                                label={usernameLabel || 'Username'}
-                                name="username"
-                                variant="filled"
-                                value={username}
-                                error={shouldValidateUsername && !isUsernameValid}
-                                helperText={shouldValidateUsername && !isUsernameValid ? usernameError : ''}
-                                {...usernameTextFieldProps}
-                                onChange={(e): void => {
-                                    // eslint-disable-next-line no-unused-expressions
-                                    usernameTextFieldProps?.onChange && usernameTextFieldProps.onChange(e);
-                                    handleUsernameInputChange(e.target.value);
+                                            ? 4
+                                            : `${(parseInt(theme.spacing(4)) + HELPER_TEXT_HEIGHT).toString()}px`,
+                                    [theme.breakpoints.down('sm')]: {
+                                        mb:
+                                            username.length > 0 && !isUsernameValid && shouldValidateUsername
+                                                ? 3
+                                                : `${(parseInt(theme.spacing(3)) + HELPER_TEXT_HEIGHT).toString()}px`,
+                                    },
                                 }}
-                                onSubmit={(e: any): void => {
-                                    // eslint-disable-next-line no-unused-expressions
-                                    usernameTextFieldProps?.onSubmit && usernameTextFieldProps.onSubmit(e);
-                                    if (e.key === 'Enter' && passwordField.current) passwordField.current.focus();
+                            >
+                                <TextField
+                                    fullWidth
+                                    id="username"
+                                    className={defaultClasses.usernameTextField}
+                                    data-testid={defaultClasses.usernameTextField}
+                                    label={usernameLabel || 'Username'}
+                                    name="username"
+                                    variant="filled"
+                                    value={username}
+                                    error={shouldValidateUsername && !isUsernameValid}
+                                    helperText={shouldValidateUsername && !isUsernameValid ? usernameError : ''}
+                                    {...usernameTextFieldProps}
+                                    onChange={(e): void => {
+                                        // eslint-disable-next-line no-unused-expressions
+                                        usernameTextFieldProps?.onChange && usernameTextFieldProps.onChange(e);
+                                        handleUsernameInputChange(e.target.value);
+                                    }}
+                                    onSubmit={(e: any): void => {
+                                        // eslint-disable-next-line no-unused-expressions
+                                        usernameTextFieldProps?.onSubmit && usernameTextFieldProps.onSubmit(e);
+                                        if (e.key === 'Enter' && passwordField.current) passwordField.current.focus();
+                                    }}
+                                    onBlur={(e): void => {
+                                        // eslint-disable-next-line no-unused-expressions
+                                        usernameTextFieldProps?.onBlur && usernameTextFieldProps.onBlur(e);
+                                        setShouldValidateUsername(true);
+                                    }}
+                                    onKeyUp={(e): void => {
+                                        if (e.key === 'Enter' && passwordField.current) passwordField.current.focus();
+                                    }}
+                                />
+                            </Box>
+                            <Box
+                                sx={{
+                                    width: '100%',
+                                    mb:
+                                        username.length > 0 && !isPasswordValid && shouldValidatePassword
+                                            ? 2
+                                            : `${(parseInt(theme.spacing(2)) + HELPER_TEXT_HEIGHT).toString()}px`,
                                 }}
-                                onBlur={(e): void => {
-                                    // eslint-disable-next-line no-unused-expressions
-                                    usernameTextFieldProps?.onBlur && usernameTextFieldProps.onBlur(e);
-                                    setShouldValidateUsername(true);
-                                }}
-                                onKeyPress={(e): void => {
-                                    if (e.key === 'Enter' && passwordField.current) passwordField.current.focus();
-                                }}
-                            />
+                            >
+                                <PasswordTextField
+                                    fullWidth
+                                    inputRef={passwordField}
+                                    id="password"
+                                    className={defaultClasses.passwordTextField}
+                                    data-testid={defaultClasses.passwordTextField}
+                                    name="password"
+                                    label={passwordLabel || 'Password'}
+                                    variant="filled"
+                                    value={password}
+                                    error={shouldValidatePassword && !isPasswordValid}
+                                    helperText={shouldValidatePassword && !isPasswordValid ? passwordError : ''}
+                                    {...passwordTextFieldProps}
+                                    onChange={(e: any): void => {
+                                        // eslint-disable-next-line no-unused-expressions
+                                        passwordTextFieldProps?.onChange && passwordTextFieldProps.onChange(e);
+                                        handlePasswordInputChange(e.target.value);
+                                    }}
+                                    onSubmit={(e: any): void => {
+                                        // eslint-disable-next-line no-unused-expressions
+                                        passwordTextFieldProps?.onSubmit && passwordTextFieldProps.onSubmit(e);
+                                        handleLoginSubmit(e);
+                                    }}
+                                    onBlur={(e): void => {
+                                        // eslint-disable-next-line no-unused-expressions
+                                        passwordTextFieldProps?.onBlur && passwordTextFieldProps.onBlur(e);
+                                        setShouldValidatePassword(true);
+                                    }}
+                                    onKeyUp={(e): void => {
+                                        // eslint-disable-next-line no-unused-expressions
+                                        passwordTextFieldProps?.onSubmit && passwordTextFieldProps.onSubmit(e);
+                                        handleLoginSubmit(e);
+                                    }}
+                                />
+                            </Box>
                         </Box>
-                        <Box
-                            sx={{
-                                width: '100%',
-                                mb:
-                                    username.length > 0 && !isPasswordValid && shouldValidatePassword
-                                        ? 2
-                                        : `${(parseInt(theme.spacing(2)) + HELPER_TEXT_HEIGHT).toString()}px`,
-                            }}
-                        >
-                            <PasswordTextField
-                                fullWidth
-                                inputRef={passwordField}
-                                id="password"
-                                className={defaultClasses.passwordTextField}
-                                data-testid={defaultClasses.passwordTextField}
-                                name="password"
-                                label={passwordLabel || 'Password'}
-                                variant="filled"
-                                value={password}
-                                error={shouldValidatePassword && !isPasswordValid}
-                                helperText={shouldValidatePassword && !isPasswordValid ? passwordError : ''}
-                                {...passwordTextFieldProps}
-                                onChange={(e: any): void => {
-                                    // eslint-disable-next-line no-unused-expressions
-                                    passwordTextFieldProps?.onChange && passwordTextFieldProps.onChange(e);
-                                    handlePasswordInputChange(e.target.value);
-                                }}
-                                onSubmit={(e: any): void => {
-                                    // eslint-disable-next-line no-unused-expressions
-                                    passwordTextFieldProps?.onSubmit && passwordTextFieldProps.onSubmit(e);
-                                    handleLoginSubmit(e);
-                                }}
-                                onBlur={(e): void => {
-                                    // eslint-disable-next-line no-unused-expressions
-                                    passwordTextFieldProps?.onBlur && passwordTextFieldProps.onBlur(e);
-                                    setShouldValidatePassword(true);
-                                }}
-                                onKeyPress={(e): void => {
-                                    // eslint-disable-next-line no-unused-expressions
-                                    passwordTextFieldProps?.onSubmit && passwordTextFieldProps.onSubmit(e);
-                                    handleLoginSubmit(e);
-                                }}
-                            />
-                        </Box>
-                    </Box>
-                    {showErrorMessageBox && errorDisplayConfig?.position === 'bottom' && errorMessageBox}
+                    </ErrorManager>
                     <Box
                         sx={{
                             display: 'flex',

--- a/login-workflow/src/new-architecture/screens/LoginScreen/LoginScreenBase.tsx
+++ b/login-workflow/src/new-architecture/screens/LoginScreen/LoginScreenBase.tsx
@@ -204,9 +204,6 @@ export const LoginScreenBase: React.FC<React.PropsWithChildren<LoginScreenProps>
         }
     };
 
-    //eslint-disable-next-line no-console
-    console.log('errorconfig:', errorDisplayConfig);
-
     return (
         <>
             <WorkflowCard className={defaultClasses.root} data-testid={defaultClasses.root}>

--- a/login-workflow/src/new-architecture/screens/LoginScreen/LoginScreenBase.tsx
+++ b/login-workflow/src/new-architecture/screens/LoginScreen/LoginScreenBase.tsx
@@ -14,6 +14,7 @@ import { HELPER_TEXT_HEIGHT } from '../../utils/constants';
 import { LoginScreenClassKey, getLoginScreenUtilityClass } from './utilityClasses';
 import { unstable_composeClasses as composeClasses } from '@mui/base';
 import ErrorManager from '../../components/Error/ErrorManager';
+import { LinkStyles } from '../../styles';
 
 /**
  * Component that renders a login screen that prompts a user to enter a username and password to login.

--- a/login-workflow/src/new-architecture/screens/LoginScreen/LoginScreenBase.tsx
+++ b/login-workflow/src/new-architecture/screens/LoginScreen/LoginScreenBase.tsx
@@ -124,9 +124,6 @@ export const LoginScreenBase: React.FC<React.PropsWithChildren<LoginScreenProps>
         footer,
     } = props;
 
-    // eslint-disable-next-line no-console
-    console.log('errorDisplayconfig from login base', errorDisplayConfig);
-
     const theme = useTheme();
     const defaultClasses = useUtilityClasses(props);
 
@@ -206,6 +203,9 @@ export const LoginScreenBase: React.FC<React.PropsWithChildren<LoginScreenProps>
             void handleLogin();
         }
     };
+
+    //eslint-disable-next-line no-console
+    console.log('errorconfig:', errorDisplayConfig);
 
     return (
         <>
@@ -487,7 +487,6 @@ export const LoginScreenBase: React.FC<React.PropsWithChildren<LoginScreenProps>
                     )}
                 </WorkflowCardBody>
             </WorkflowCard>
-            {/* <ErrorDialog /> */}
         </>
     );
 };

--- a/login-workflow/src/new-architecture/screens/LoginScreen/types.ts
+++ b/login-workflow/src/new-architecture/screens/LoginScreen/types.ts
@@ -1,22 +1,23 @@
 import { TextFieldProps } from '@mui/material';
 import { WorkflowCardBaseProps } from '../../components/WorkflowCard/WorkflowCard.types';
+import { ErrorManagerProps } from '../../components/Error';
 
-export type LoginErrorDialogConfiguration = {
-    title?: string;
-    content?: string;
-    acknowledgeButtonLabel?: string;
-    onAcknowledgeError?: () => void;
-};
+// export type LoginErrorDialogConfiguration = {
+//     title?: string;
+//     content?: string;
+//     acknowledgeButtonLabel?: string;
+//     onAcknowledgeError?: () => void;
+// };
 
-export type LoginErrorDisplayConfiguration = {
-    error?: boolean | string;
-    mode?: 'dialog' | 'message-box' | 'both' | 'none';
-    dismissible?: boolean;
-    position?: 'top' | 'bottom';
-    fontColor?: string;
-    backgroundColor?: string;
-    dialogErrorConfig?: LoginErrorDialogConfiguration;
-};
+// export type LoginErrorDisplayConfiguration = {
+//     error?: boolean | string;
+//     mode?: 'dialog' | 'message-box' | 'both' | 'none';
+//     dismissible?: boolean;
+//     position?: 'top' | 'bottom';
+//     fontColor?: string;
+//     backgroundColor?: string;
+//     dialogErrorConfig?: LoginErrorDialogConfiguration;
+// };
 
 export type LoginScreenProps = WorkflowCardBaseProps & {
     // configure fields
@@ -55,7 +56,7 @@ export type LoginScreenProps = WorkflowCardBaseProps & {
     onContactSupport?: () => void;
 
     // configure visual customizations
-    errorDisplayConfig?: LoginErrorDisplayConfiguration;
+    errorDisplayConfig?: ErrorManagerProps;
     showCyberSecurityBadge?: boolean;
     projectImage?: React.ReactNode;
     header?: JSX.Element;

--- a/login-workflow/src/new-architecture/screens/LoginScreen/types.ts
+++ b/login-workflow/src/new-architecture/screens/LoginScreen/types.ts
@@ -2,23 +2,6 @@ import { TextFieldProps } from '@mui/material';
 import { WorkflowCardBaseProps } from '../../components/WorkflowCard/WorkflowCard.types';
 import { ErrorManagerProps } from '../../components/Error';
 
-// export type LoginErrorDialogConfiguration = {
-//     title?: string;
-//     content?: string;
-//     acknowledgeButtonLabel?: string;
-//     onAcknowledgeError?: () => void;
-// };
-
-// export type LoginErrorDisplayConfiguration = {
-//     error?: boolean | string;
-//     mode?: 'dialog' | 'message-box' | 'both' | 'none';
-//     dismissible?: boolean;
-//     position?: 'top' | 'bottom';
-//     fontColor?: string;
-//     backgroundColor?: string;
-//     dialogErrorConfig?: LoginErrorDialogConfiguration;
-// };
-
 export type LoginScreenProps = WorkflowCardBaseProps & {
     // configure fields
     usernameLabel?: string;

--- a/login-workflow/src/new-architecture/screens/VerifyCodeScreen/VerifyCodeScreen.tsx
+++ b/login-workflow/src/new-architecture/screens/VerifyCodeScreen/VerifyCodeScreen.tsx
@@ -3,6 +3,8 @@ import { VerifyCodeScreenBase } from './VerifyCodeScreenBase';
 import { VerifyCodeScreenProps } from './types';
 import { useLanguageLocale } from '../../hooks';
 import { useRegistrationContext, useRegistrationWorkflowContext } from '../../contexts';
+import { AuthError } from '../../components/Error';
+import { useErrorContext } from '../../contexts/ErrorContext';
 
 /**
  * Component that renders a screen that prompts a user to enter the confirmation code
@@ -22,17 +24,24 @@ export const VerifyCodeScreen: React.FC<VerifyCodeScreenProps> = (props) => {
     const regWorkflow = useRegistrationWorkflowContext();
     const { actions } = useRegistrationContext();
     const { nextScreen, previousScreen, screenData } = regWorkflow;
+    const errorConfig = useErrorContext();
     const { emailAddress } = screenData.CreateAccount;
 
     const [verifyCode, setVerifyCode] = useState(screenData.VerifyCode.code);
     const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<AuthError>({ cause: { title: '', errorMessage: '' } });
 
     const requestResendCode = useCallback(async (): Promise<void> => {
         try {
             setIsLoading(true);
             await actions().requestRegistrationCode(emailAddress ? emailAddress : '');
-        } catch {
-            console.error('Error fetching resend verification code!');
+        } catch (_error) {
+            setError({
+                cause: {
+                    title: (_error as AuthError).cause.title,
+                    errorMessage: (_error as AuthError).cause.errorMessage,
+                },
+            });
         } finally {
             setIsLoading(false);
         }
@@ -48,6 +57,7 @@ export const VerifyCodeScreen: React.FC<VerifyCodeScreenProps> = (props) => {
         resendLabel = t('bluiCommon:ACTIONS.RESEND'),
         verifyCodeInputLabel = t('bluiRegistration:SELF_REGISTRATION.VERIFY_EMAIL.VERIFICATION'),
         initialValue = verifyCode,
+        errorDisplayConfig = errorConfig,
     } = props;
 
     const handleOnNext = useCallback(
@@ -59,8 +69,13 @@ export const VerifyCodeScreen: React.FC<VerifyCodeScreenProps> = (props) => {
                     screenId: 'VerifyCode',
                     values: { code: code },
                 });
-            } catch {
-                console.error('Error fetching validation code!');
+            } catch (_error) {
+                setError({
+                    cause: {
+                        title: (_error as AuthError).cause.title,
+                        errorMessage: (_error as AuthError).cause.errorMessage,
+                    },
+                });
             } finally {
                 setIsLoading(false);
             }
@@ -125,6 +140,14 @@ export const VerifyCodeScreen: React.FC<VerifyCodeScreenProps> = (props) => {
             initialValue={initialValue}
             onResend={onResend}
             codeValidator={codeValidator}
+            errorDisplayConfig={{
+                ...errorDisplayConfig,
+                title: error.cause.title,
+                errorMessage: error.cause.errorMessage,
+                onClose: (): void => {
+                    setError({ cause: { title: '', errorMessage: '' } });
+                },
+            }}
         />
     );
 };

--- a/login-workflow/src/new-architecture/screens/VerifyCodeScreen/VerifyCodeScreenBase.tsx
+++ b/login-workflow/src/new-architecture/screens/VerifyCodeScreen/VerifyCodeScreenBase.tsx
@@ -8,6 +8,7 @@ import { WorkflowCardInstructions } from '../../components/WorkflowCard/Workflow
 import TextField from '@mui/material/TextField';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import ErrorManager from '../../components/Error/ErrorManager';
 
 /**
  * Component that renders a screen that prompts a user to enter the confirmation code
@@ -23,7 +24,15 @@ import Typography from '@mui/material/Typography';
  */
 
 export const VerifyCodeScreenBase: React.FC<React.PropsWithChildren<VerifyCodeScreenProps>> = (props) => {
-    const { codeValidator, onResend, resendInstructions, resendLabel, verifyCodeInputLabel, initialValue } = props;
+    const {
+        codeValidator,
+        onResend,
+        resendInstructions,
+        resendLabel,
+        verifyCodeInputLabel,
+        initialValue,
+        errorDisplayConfig,
+    } = props;
 
     const cardBaseProps = props.WorkflowCardBaseProps || {};
     const headerProps = props.WorkflowCardHeaderProps || {};
@@ -62,36 +71,38 @@ export const VerifyCodeScreenBase: React.FC<React.PropsWithChildren<VerifyCodeSc
             <WorkflowCardHeader {...headerProps}></WorkflowCardHeader>
             <WorkflowCardBody>
                 <WorkflowCardInstructions {...instructionsProps} divider />
-                <TextField
-                    label={verifyCodeInputLabel}
-                    fullWidth
-                    value={verifyCode}
-                    onChange={(evt): void => {
-                        handleVerifyCodeInputChange(evt.target.value);
-                    }}
-                    onKeyUp={(e): void => {
-                        if (e.key === 'Enter' && verifyCode.length > 0 && isCodeValid && actionsProps.canGoNext)
-                            handleOnNext();
-                    }}
-                    variant="filled"
-                    error={shouldValidateCode && !isCodeValid}
-                    helperText={shouldValidateCode && codeError}
-                    onBlur={(): void => setShouldValidateCode(true)}
-                />
-                <Box sx={{ mt: 2 }}>
-                    <Typography>
-                        {resendInstructions}
-                        <Typography
-                            sx={{ fontSize: 'inherit', textTransform: 'initial', '&:hover': { cursor: 'pointer' } }}
-                            onClick={(): void => onResend()}
-                            color="primary"
-                            variant={'button'}
-                        >
-                            {' '}
-                            <u>{resendLabel}</u>
+                <ErrorManager {...errorDisplayConfig}>
+                    <TextField
+                        label={verifyCodeInputLabel}
+                        fullWidth
+                        value={verifyCode}
+                        onChange={(evt): void => {
+                            handleVerifyCodeInputChange(evt.target.value);
+                        }}
+                        onKeyUp={(e): void => {
+                            if (e.key === 'Enter' && verifyCode.length > 0 && isCodeValid && actionsProps.canGoNext)
+                                handleOnNext();
+                        }}
+                        variant="filled"
+                        error={shouldValidateCode && !isCodeValid}
+                        helperText={shouldValidateCode && codeError}
+                        onBlur={(): void => setShouldValidateCode(true)}
+                    />
+                    <Box sx={{ mt: 2 }}>
+                        <Typography>
+                            {resendInstructions}
+                            <Typography
+                                sx={{ fontSize: 'inherit', textTransform: 'initial', '&:hover': { cursor: 'pointer' } }}
+                                onClick={(): void => onResend()}
+                                color="primary"
+                                variant={'button'}
+                            >
+                                {' '}
+                                <u>{resendLabel}</u>
+                            </Typography>
                         </Typography>
-                    </Typography>
-                </Box>
+                    </Box>
+                </ErrorManager>
             </WorkflowCardBody>
             <WorkflowCardActions
                 {...actionsProps}

--- a/login-workflow/src/new-architecture/screens/VerifyCodeScreen/types.ts
+++ b/login-workflow/src/new-architecture/screens/VerifyCodeScreen/types.ts
@@ -1,3 +1,4 @@
+import { ErrorManagerProps } from '../../components/Error';
 import { WorkflowCardProps } from '../../components/WorkflowCard/WorkflowCard.types';
 
 export type VerifyCodeScreenProps = WorkflowCardProps & {
@@ -18,4 +19,6 @@ export type VerifyCodeScreenProps = WorkflowCardProps & {
 
     // used to set the label for verify code input
     verifyCodeInputLabel?: string;
+
+    errorDisplayConfig?: ErrorManagerProps;
 };


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes BLUI-4401.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Add ErrorManager and ErrorMessageBox
- Manage API errors via ErrorManager for all components that make API calls

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- add 
``` 
throw new Error('My Custom Error', {
    cause: {
        title: 'Custom Title',
        errorMessage: 'My custom error message',
    },
});
```
to the beginning of the corresponding auth or registration action so that an error is thrown and the corresponding component that calls that action will render the appropriate error. By default the error message will be rendered inside of an error dialog. In order to test the message box simple change the props via the AuthContextProvider or the RegistrationContextProvider as follows:
```
 <AuthContextProvider
                    ...
                    errorConfig={{
                        mode: 'message-box',
                        dismissible: true,
                        position: 'top',
                    }}
                >
```
Feel free to check out the types definition and mess around with all of the props to ensure they all work.
 

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
