### PR TITLE
Bug/4501 added verifyresetcode validate in the reset password

### DIFF
--- a/login-workflow/example/src/actions/AuthUIActions.tsx
+++ b/login-workflow/example/src/actions/AuthUIActions.tsx
@@ -132,7 +132,6 @@ export const ProjectAuthUIActions: AuthUIActionsWithApp = (appHelper) => (): Aut
         if (isRandomFailure()) {
             throw new Error('Sorry, there was a problem sending your request.');
         }
-        console.log('action code value', code);
         return code === '123';
     },
     /**

--- a/login-workflow/example/src/actions/AuthUIActions.tsx
+++ b/login-workflow/example/src/actions/AuthUIActions.tsx
@@ -127,13 +127,13 @@ export const ProjectAuthUIActions: AuthUIActionsWithApp = (appHelper) => (): Aut
      *
      * @returns Resolve if code is valid, otherwise reject.
      */
-    verifyResetCode: async (code: string, email?: string): Promise<void> => {
+    verifyResetCode: async (code: string, email?: string): Promise<any> => {
         await sleep(500);
         if (isRandomFailure()) {
             throw new Error('Sorry, there was a problem sending your request.');
         }
-
-        return;
+        console.log('action code value', code);
+        return code === '123';
     },
     /**
      * A user who has previously used "forgotPassword" now has a valid password reset code

--- a/login-workflow/src/new-architecture/contexts/AuthContext/types.ts
+++ b/login-workflow/src/new-architecture/contexts/AuthContext/types.ts
@@ -30,7 +30,7 @@ export type AuthUIActions = {
     initiateSecurity: () => Promise<void>;
     logIn: (email: string, password: string, rememberMe: boolean) => Promise<void>;
     forgotPassword: (email: string) => Promise<void>;
-    verifyResetCode: (code: string, email?: string) => Promise<any>;
+    verifyResetCode: (code: string, email?: string) => Promise<void>;
     setPassword: (code: string, password: string, email?: string) => Promise<void>;
     changePassword: (oldPassword: string, newPassword: string) => Promise<void>;
 };

--- a/login-workflow/src/new-architecture/contexts/AuthContext/types.ts
+++ b/login-workflow/src/new-architecture/contexts/AuthContext/types.ts
@@ -30,7 +30,7 @@ export type AuthUIActions = {
     initiateSecurity: () => Promise<void>;
     logIn: (email: string, password: string, rememberMe: boolean) => Promise<void>;
     forgotPassword: (email: string) => Promise<void>;
-    verifyResetCode: (code: string, email?: string) => Promise<void>;
+    verifyResetCode: (code: string, email?: string) => Promise<any>;
     setPassword: (code: string, password: string, email?: string) => Promise<void>;
     changePassword: (oldPassword: string, newPassword: string) => Promise<void>;
 };

--- a/login-workflow/src/new-architecture/screens/ResetPasswordScreen/ResetPasswordScreen.tsx
+++ b/login-workflow/src/new-architecture/screens/ResetPasswordScreen/ResetPasswordScreen.tsx
@@ -7,6 +7,7 @@ import { defaultPasswordRequirements } from '../../constants';
 import { parseQueryString } from '../../utils';
 import { ResetPasswordScreenProps } from './types';
 import { useErrorManager } from '../../contexts/ErrorContext/useErrorManager';
+import { ErrorManagerProps } from '../../components/Error';
 
 /**
  * Component that renders a ResetPassword screen that allows a user to reset their password and shows a success message upon a successful password reset..
@@ -80,7 +81,7 @@ export const ResetPasswordScreen: React.FC<ResetPasswordScreenProps> = (props) =
         [setPasswordInput, setConfirmInput]
     );
 
-    const errorConfig = {
+    const errorConfig: ErrorManagerProps = {
         mode: 'dialog',
         error: errorMsg,
         dialogConfig: {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #added verifyresetcode validate in the reset password .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

-
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- yarn start:example
- open the link http://localhost:3000/reset-password?code=123&email=test@test.com
- for testing purpose verifyResetCode function will validate url code with static value of 123. If you pass different code value in the url to test the functionality.

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
