### PR TITLE
Fix issue where initial values were not being rendered

### DIFF
--- a/login-workflow/src/screens/AccountDetailsScreen/AccountDetailsScreen.tsx
+++ b/login-workflow/src/screens/AccountDetailsScreen/AccountDetailsScreen.tsx
@@ -9,8 +9,8 @@ export const AccountDetailsScreen: React.FC<AccountDetailsScreenProps> = (props)
     const { actions } = useRegistrationContext();
     const regWorkflow = useRegistrationWorkflowContext();
     const { nextScreen, previousScreen, screenData, currentScreen, totalScreens } = regWorkflow;
-    const [firstName, setFirstName] = useState(screenData.AccountDetails.firstName ?? '');
-    const [lastName, setLastName] = useState(screenData.AccountDetails.lastName ?? '');
+    const [firstName, setFirstName] = useState(screenData.AccountDetails.firstName);
+    const [lastName, setLastName] = useState(screenData.AccountDetails.lastName);
     const [isLoading, setIsLoading] = useState(false);
     const { triggerError, errorManagerConfig } = useErrorManager();
 
@@ -58,6 +58,8 @@ export const AccountDetailsScreen: React.FC<AccountDetailsScreenProps> = (props)
         errorDisplayConfig = errorManagerConfig,
         firstNameTextFieldProps,
         lastNameTextFieldProps,
+        initialFirstName = screenData.AccountDetails.firstName,
+        initialLastName = screenData.AccountDetails.lastName,
     } = props;
 
     const workflowCardHeaderProps = {
@@ -106,8 +108,8 @@ export const AccountDetailsScreen: React.FC<AccountDetailsScreenProps> = (props)
             WorkflowCardBaseProps={workflowCardBaseProps}
             WorkflowCardHeaderProps={workflowCardHeaderProps}
             WorkflowCardInstructionProps={workflowCardInstructionProps}
-            initialFirstName={firstName}
-            initialLastName={lastName}
+            initialFirstName={firstName.length > 0 ? firstName : initialFirstName}
+            initialLastName={lastName.length > 0 ? lastName : initialLastName}
             firstNameLabel={firstNameLabel}
             firstNameTextFieldProps={{ ...firstNameTextFieldProps, onChange: onFirstNameInputChange }}
             firstNameValidator={firstNameValidator}


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes BLUI-4593.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Fix issue where initial values were not being rendered


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Modify the RegistrationWorkflow route in the example app's `AppRouter.tsx` file to look like the following:
```
 <Route
       path={'/self-registration'}
       element={
            <RegistrationWorkflow>
               <EulaScreen />
               <CreateAccountScreen/>
               <AccountDetailsScreen initialFirstName="Bob" initialLastName="Ross" />
            </RegistrationWorkflow>
         }
/>
```
- Start the example project and click "create account"
- Ensure that the default values render when you get to the AccountDetailsScreen in the workflow
- Modify the inputs and navigate back and forth to ensure that the screendata value persists and are not overridden by the initialvalues
