### PR TITLE
Fix ErrorManager bugs

### DIFF
--- a/login-workflow/src/components/Error/ErrorManager.tsx
+++ b/login-workflow/src/components/Error/ErrorManager.tsx
@@ -2,13 +2,14 @@ import { SxProps } from '@mui/material/styles';
 import React, { useCallback } from 'react';
 import { BasicDialog } from '../Dialog/BasicDialog';
 import ErrorMessageBox from './ErrorMessageBox';
+import { useLanguageLocale } from '../../hooks';
 
 export type AuthError = { cause: { title: string; errorMessage: string } };
 
 export type ErrorManagerProps = {
     mode?: 'dialog' | 'message-box' | 'none';
     onClose?: () => void;
-    error: string;
+    error?: string;
     dialogConfig?: {
         title?: string;
         dismissLabel?: string;
@@ -42,10 +43,20 @@ export type ErrorManagerProps = {
  */
 
 const ErrorManager: React.FC<ErrorManagerProps> = (props): JSX.Element => {
-    const { children, mode = 'dialog', error, onClose, dialogConfig, messageBoxConfig } = props;
+    const { t } = useLanguageLocale();
+    const {
+        children,
+        mode = 'dialog',
+        error = '',
+        onClose = (): void => {},
+        dialogConfig,
+        messageBoxConfig = {
+            position: 'top',
+        },
+    } = props;
 
     const ErrorDialogWithProps = useCallback((): JSX.Element => {
-        const { title, dismissLabel } = dialogConfig;
+        const { title = t('bluiCommon:MESSAGES.ERROR'), dismissLabel } = dialogConfig;
 
         return (
             <BasicDialog
@@ -73,14 +84,14 @@ const ErrorManager: React.FC<ErrorManagerProps> = (props): JSX.Element => {
         );
     }, [error, messageBoxConfig, onClose]);
 
-    return mode === 'dialog' && error ? (
+    return mode === 'dialog' && error.length > 0 ? (
         <>
             {children}
             <ErrorDialogWithProps />
         </>
-    ) : mode === 'message-box' && error ? (
+    ) : mode === 'message-box' && error.length > 0 ? (
         <>
-            {messageBoxConfig.position === 'top' && <ErrorMessageBoxWithProps />}
+            {messageBoxConfig.position !== 'bottom' && <ErrorMessageBoxWithProps />}
             {children}
             {messageBoxConfig.position === 'bottom' && <ErrorMessageBoxWithProps />}
         </>

--- a/login-workflow/src/screens/AccountDetailsScreen/AccountDetailsScreen.tsx
+++ b/login-workflow/src/screens/AccountDetailsScreen/AccountDetailsScreen.tsx
@@ -13,6 +13,7 @@ export const AccountDetailsScreen: React.FC<AccountDetailsScreenProps> = (props)
     const [lastName, setLastName] = useState(screenData.AccountDetails.lastName ?? '');
     const [isLoading, setIsLoading] = useState(false);
     const { triggerError, errorManagerConfig } = useErrorManager();
+    const errorDisplayConfig = { ...errorManagerConfig, ...props.errorDisplayConfig };
 
     const onNext = useCallback(async (): Promise<void> => {
         try {
@@ -55,7 +56,6 @@ export const AccountDetailsScreen: React.FC<AccountDetailsScreenProps> = (props)
             }
             return t('bluiCommon:FORMS.LAST_NAME_LENGTH_ERROR');
         },
-        errorDisplayConfig = errorManagerConfig,
         firstNameTextFieldProps,
         lastNameTextFieldProps,
     } = props;

--- a/login-workflow/src/screens/CreateAccountScreen/CreateAccountScreen.tsx
+++ b/login-workflow/src/screens/CreateAccountScreen/CreateAccountScreen.tsx
@@ -27,6 +27,7 @@ export const CreateAccountScreen: React.FC<CreateAccountScreenProps> = (props) =
     const [emailInputValue, setEmailInputValue] = useState(screenData.CreateAccount.emailAddress);
     const [isLoading, setIsLoading] = useState(false);
     const { triggerError, errorManagerConfig } = useErrorManager();
+    const errorDisplayConfig = { ...errorManagerConfig, ...props.errorDisplayConfig };
 
     const onNext = useCallback(async () => {
         try {
@@ -64,7 +65,6 @@ export const CreateAccountScreen: React.FC<CreateAccountScreenProps> = (props) =
             return true;
         },
         emailTextFieldProps,
-        errorDisplayConfig = errorManagerConfig,
     } = props;
 
     const workflowCardBaseProps = {

--- a/login-workflow/src/screens/CreatePasswordScreen/CreatePasswordScreen.tsx
+++ b/login-workflow/src/screens/CreatePasswordScreen/CreatePasswordScreen.tsx
@@ -26,6 +26,7 @@ export const CreatePasswordScreen: React.FC<CreatePasswordScreenProps> = (props)
     const [isLoading, setIsLoading] = useState(false);
     const passwordRequirements = defaultPasswordRequirements(t);
     const { triggerError, errorManagerConfig } = useErrorManager();
+    const errorDisplayConfig = { ...errorManagerConfig, ...props.errorDisplayConfig };
 
     const onNext = useCallback(async (): Promise<void> => {
         try {
@@ -70,7 +71,6 @@ export const CreatePasswordScreen: React.FC<CreatePasswordScreenProps> = (props)
         WorkflowCardInstructionProps,
         WorkflowCardActionsProps,
         PasswordProps,
-        errorDisplayConfig = errorManagerConfig,
     } = props;
 
     const workflowCardBaseProps = {

--- a/login-workflow/src/screens/EulaScreen/EulaScreen.tsx
+++ b/login-workflow/src/screens/EulaScreen/EulaScreen.tsx
@@ -9,6 +9,7 @@ export const EulaScreen: React.FC<EulaScreenProps> = (props) => {
     const { t } = useLanguageLocale();
     const { actions, navigate, routeConfig, language } = useRegistrationContext();
     const { triggerError, errorManagerConfig } = useErrorManager();
+    const errorDisplayConfig = { ...errorManagerConfig, ...props.errorDisplayConfig };
     const regWorkflow = useRegistrationWorkflowContext();
     const { nextScreen, previousScreen, screenData, currentScreen, totalScreens, isInviteRegistration } = regWorkflow;
     const {
@@ -18,7 +19,6 @@ export const EulaScreen: React.FC<EulaScreenProps> = (props) => {
         eulaContent,
         checkboxLabel = t('bluiRegistration:REGISTRATION.EULA.AGREE_TERMS'),
         initialCheckboxValue,
-        errorDisplayConfig = errorManagerConfig,
     } = props;
 
     const [eulaAccepted, setEulaAccepted] = useState(screenData.Eula.accepted ?? initialCheckboxValue);

--- a/login-workflow/src/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
+++ b/login-workflow/src/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
@@ -14,6 +14,7 @@ export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props)
     const { t } = useLanguageLocale();
     const { actions, navigate, routeConfig } = useAuthContext();
     const { triggerError, errorManagerConfig } = useErrorManager();
+    const errorDisplayConfig = { ...errorManagerConfig, ...props.errorDisplayConfig };
 
     const [emailInput, setEmailInput] = useState('');
     const [isLoading, setIsLoading] = useState(false);
@@ -57,7 +58,6 @@ export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props)
         showSuccessScreen: enableSuccessScreen = true,
         slotProps = { SuccessScreen: {} },
         slots,
-        errorDisplayConfig = errorManagerConfig,
     } = props;
 
     const workflowCardBaseProps = {

--- a/login-workflow/src/screens/LoginScreen/LoginScreen.tsx
+++ b/login-workflow/src/screens/LoginScreen/LoginScreen.tsx
@@ -49,6 +49,7 @@ export const LoginScreen: React.FC<React.PropsWithChildren<LoginScreenPropsPubli
     const auth = useAuthContext();
     const { actions, navigate, routeConfig, rememberMeDetails } = auth;
     const { triggerError, errorManagerConfig } = useErrorManager();
+    const errorDisplayConfig = { ...errorManagerConfig, ...props.errorDisplayConfig };
 
     useEffect(() => {
         void actions().initiateSecurity();
@@ -85,7 +86,6 @@ export const LoginScreen: React.FC<React.PropsWithChildren<LoginScreenPropsPubli
         showContactSupport = true,
         contactSupportLabel = t('bluiCommon:MESSAGES.CONTACT'),
         onContactSupport = (): void => navigate(routeConfig.SUPPORT),
-        errorDisplayConfig = errorManagerConfig,
         showCyberSecurityBadge = true,
         projectImage,
         header,

--- a/login-workflow/src/screens/VerifyCodeScreen/VerifyCodeScreen.tsx
+++ b/login-workflow/src/screens/VerifyCodeScreen/VerifyCodeScreen.tsx
@@ -25,6 +25,7 @@ export const VerifyCodeScreen: React.FC<VerifyCodeScreenProps> = (props) => {
     const { nextScreen, previousScreen, screenData, currentScreen, totalScreens } = regWorkflow;
     const { emailAddress } = screenData.CreateAccount;
     const { triggerError, errorManagerConfig } = useErrorManager();
+    const errorDisplayConfig = { ...errorManagerConfig, ...props.errorDisplayConfig };
 
     const [verifyCode, setVerifyCode] = useState(screenData.VerifyCode.code);
     const [isLoading, setIsLoading] = useState(false);
@@ -50,7 +51,6 @@ export const VerifyCodeScreen: React.FC<VerifyCodeScreenProps> = (props) => {
         resendLabel = t('bluiCommon:ACTIONS.RESEND'),
         verifyCodeInputLabel = t('bluiRegistration:SELF_REGISTRATION.VERIFY_EMAIL.VERIFICATION'),
         initialValue = verifyCode,
-        errorDisplayConfig = errorManagerConfig,
     } = props;
 
     const handleOnNext = useCallback(


### PR DESCRIPTION

<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes BLUI-4570.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- add default dialog config title
- add default message box position
- add default on close function
- fix object merging on full screens


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Modify the errorConfig on the Auth or registration providers and/or modify the errorDisplayConfig on individual full screens to modify how errors are displayed. You will need to throw a new error from the corresponding auth or registration actions if you want to test a specific screens error state e.g., the login method on the login screen.

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

These are the items in the issue description that need to be tested...

- If we pass 'errorDisplayConfig' props, the error UI will get render in the screen even though error is not there.
**note:** this is how the error manager works and it's not a bug. If an error is provided it will render the error. If the end user wants to manage errors to this degree they will also need to manage the entire flow for showing and hiding the error. This is demonstrated in the advanced usage section of the error-manager component documentation.
- If we pass only 'error' prop in the errorDisplayConfig, application will break since 'title' prop is undefined in 'dialogConfig' prop.
- If we pass 'message-box' as prop to 'mode', application will break since 'position' prop is undefined in the 'messageBoxConfig' prop.
- Default onClose event is not defined.
