### PR TITLE
Feature/4498 - Block advancement and allow for refetching EULA when app fails to fetch EULA

### DIFF
--- a/login-workflow/example/src/actions/RegistrationUIActions.tsx
+++ b/login-workflow/example/src/actions/RegistrationUIActions.tsx
@@ -33,7 +33,7 @@ export const ProjectRegistrationUIActions: () => RegistrationUIActions = () => (
     loadEula: async (language: string): Promise<string> => {
         await sleep(1000);
 
-        if (true) {
+        if (isRandomFailure()) {
             throw new Error('Sorry, there was a problem sending your request.');
         }
 

--- a/login-workflow/example/src/actions/RegistrationUIActions.tsx
+++ b/login-workflow/example/src/actions/RegistrationUIActions.tsx
@@ -33,7 +33,7 @@ export const ProjectRegistrationUIActions: () => RegistrationUIActions = () => (
     loadEula: async (language: string): Promise<string> => {
         await sleep(1000);
 
-        if (isRandomFailure()) {
+        if (true) {
             throw new Error('Sorry, there was a problem sending your request.');
         }
 

--- a/login-workflow/src/components/WorkflowCard/WorkflowCardBody.tsx
+++ b/login-workflow/src/components/WorkflowCard/WorkflowCardBody.tsx
@@ -8,9 +8,9 @@ export const WorkflowCardBody: React.FC<CardContentProps> = (props) => {
         <CardContent
             sx={[
                 {
-                    flex: '1 1 0px',
-                    overflow: 'auto',
                     display: 'flex',
+                    flex: '1 1 0',
+                    overflow: 'auto',
                     flexDirection: 'column',
                     pt: 2,
                     pb: { sm: 3, md: 2 },

--- a/login-workflow/src/screens/EulaScreen/EulaScreen.test.tsx
+++ b/login-workflow/src/screens/EulaScreen/EulaScreen.test.tsx
@@ -47,12 +47,6 @@ describe('Eula Screen', () => {
         expect(screen.getByText('Test Title')).toBeInTheDocument();
     });
 
-    it('should show loader, when loading prop is passed to WorkflowCardBaseProps', () => {
-        renderer({ WorkflowCardBaseProps: { loading: true } });
-
-        expect(screen.getByText('Loading End User License Agreement...')).toBeInTheDocument();
-    });
-
     it('should update content of Eula Screen when eulaContent prop set ', () => {
         renderer({ eulaContent: 'Test Eula Content' });
         expect(screen.getByText('Test Eula Content')).toBeInTheDocument();

--- a/login-workflow/src/screens/EulaScreen/EulaScreen.tsx
+++ b/login-workflow/src/screens/EulaScreen/EulaScreen.tsx
@@ -24,20 +24,24 @@ export const EulaScreen: React.FC<EulaScreenProps> = (props) => {
     const [eulaAccepted, setEulaAccepted] = useState(screenData.Eula.accepted ?? initialCheckboxValue);
     const [isLoading, setIsLoading] = useState(true);
     const [eulaData, setEulaData] = useState<string>();
+    const [isError, setIsError] = useState(false);
 
     const loadAndCacheEula = useCallback(async (): Promise<void> => {
+        setIsLoading(true);
         if (!eulaContent) {
             setEulaData(t('bluiRegistration:REGISTRATION.EULA.LOADING'));
             try {
                 const eulaText = await actions().loadEula(language);
                 setEulaData(eulaText);
                 setIsLoading(false);
+                setIsError(false);
             } catch (_error) {
                 // @TODO: we need to handle this failure more gracefully. The user should be able to attempt to reload the EULA and forward progress should be blocked
                 triggerError(_error as Error);
                 // @TODO: replace this hardcoded string with a proper error text translation
                 // setEulaData('End user license agreement failed to load');
                 // setEulaData(t('bluiRegistration:REGISTRATION.FAILURE_MESSAGE'));
+                setIsError(true);
                 setIsLoading(false);
             } finally {
                 setIsLoading(false);
@@ -93,6 +97,12 @@ export const EulaScreen: React.FC<EulaScreenProps> = (props) => {
         void loadAndCacheEula();
     }, [loadAndCacheEula]);
 
+    const {
+        onRefetch = (): void => {
+            void loadAndCacheEula();
+        },
+    } = props;
+
     const workflowCardHeaderProps = {
         title: t('bluiRegistration:REGISTRATION.STEPS.LICENSE'),
         ...WorkflowCardHeaderProps,
@@ -127,11 +137,12 @@ export const EulaScreen: React.FC<EulaScreenProps> = (props) => {
                 loading: isLoading,
             }}
             checkboxLabel={checkboxLabel}
-            checkboxProps={{ disabled: false }}
+            checkboxProps={{ disabled: isError }}
             initialCheckboxValue={eulaAccepted}
             onEulaAcceptedChange={onEulaAcceptedChange}
             WorkflowCardActionsProps={workflowCardActionsProps}
             errorDisplayConfig={errorDisplayConfig}
+            onRefetch={onRefetch}
         />
     );
 };

--- a/login-workflow/src/screens/EulaScreen/EulaScreenBase.tsx
+++ b/login-workflow/src/screens/EulaScreen/EulaScreenBase.tsx
@@ -6,8 +6,8 @@ import Checkbox from '@mui/material/Checkbox';
 import Box from '@mui/material/Box';
 import DOMPurify from 'dompurify';
 import ErrorManager from '../../components/Error/ErrorManager';
-import { Button, IconButton } from '@mui/material';
-import Autorenew from '@mui/icons-material/Autorenew';
+import { IconButton, Typography } from '@mui/material';
+import ReplaySharpIcon from '@mui/icons-material/ReplaySharp';
 
 /**
  * Component that renders a screen displaying the EULA and requests acceptance via a checkbox.
@@ -55,10 +55,28 @@ export const EulaScreenBase: React.FC<EulaScreenProps> = (props) => {
             <WorkflowCardHeader {...headerProps} />
             <WorkflowCardBody>
                 {checkboxProps.disabled ? (
-                    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', height: '100%' }}>
+                    <Box
+                        sx={{
+                            display: 'flex',
+                            flexDirection: 'column',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            height: '100%',
+                        }}
+                    >
                         <IconButton onClick={onRefetch}>
-                            <Autorenew sx={{ width: 64, height: 64 }} />
+                            <ReplaySharpIcon color="primary" sx={{ width: 64, height: 64 }} />
                         </IconButton>
+                        <Typography
+                            onClick={onRefetch}
+                            color="primary"
+                            fontSize="30px"
+                            display="block"
+                            fontWeight={600}
+                            sx={{ cursor: 'pointer' }}
+                        >
+                            Retry
+                        </Typography>
                     </Box>
                 ) : htmlEula ? (
                     <Box

--- a/login-workflow/src/screens/EulaScreen/EulaScreenBase.tsx
+++ b/login-workflow/src/screens/EulaScreen/EulaScreenBase.tsx
@@ -6,6 +6,7 @@ import Checkbox from '@mui/material/Checkbox';
 import Box from '@mui/material/Box';
 import DOMPurify from 'dompurify';
 import ErrorManager from '../../components/Error/ErrorManager';
+import { Button } from '@mui/material';
 
 /**
  * Component that renders a screen displaying the EULA and requests acceptance via a checkbox.
@@ -27,6 +28,7 @@ export const EulaScreenBase: React.FC<EulaScreenProps> = (props) => {
         initialCheckboxValue,
         checkboxProps,
         errorDisplayConfig,
+        onRefetch,
     } = props;
 
     const cardBaseProps = props.WorkflowCardBaseProps || {};
@@ -51,12 +53,24 @@ export const EulaScreenBase: React.FC<EulaScreenProps> = (props) => {
         <WorkflowCard {...cardBaseProps}>
             <WorkflowCardHeader {...headerProps} />
             <WorkflowCardBody>
-                {!htmlEula && <Box sx={{ flex: '1 1 0px', overflow: 'auto' }}>{eulaContent}</Box>}
+                {/* {!htmlEula && <Box sx={{ flex: '1 1 0px', overflow: 'auto' }}>{eulaContent}</Box>}
                 {htmlEula && (
                     <Box
                         sx={{ flex: '1 1 0px', overflow: 'auto' }}
                         dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(eulaContent as string) }}
                     />
+                )} */}
+                {checkboxProps.disabled ? (
+                    <Button variant="outlined" color="primary" onClick={onRefetch}>
+                        Refetch
+                    </Button>
+                ) : htmlEula ? (
+                    <Box
+                        sx={{ flex: '1 1 0px', overflow: 'auto' }}
+                        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(eulaContent as string) }}
+                    />
+                ) : (
+                    <Box sx={{ flex: '1 1 0px', overflow: 'auto' }}>{eulaContent}</Box>
                 )}
                 <ErrorManager {...errorDisplayConfig}>
                     <FormControlLabel

--- a/login-workflow/src/screens/EulaScreen/EulaScreenBase.tsx
+++ b/login-workflow/src/screens/EulaScreen/EulaScreenBase.tsx
@@ -6,7 +6,7 @@ import Checkbox from '@mui/material/Checkbox';
 import Box from '@mui/material/Box';
 import DOMPurify from 'dompurify';
 import ErrorManager from '../../components/Error/ErrorManager';
-import { IconButton, Typography } from '@mui/material';
+import { Typography } from '@mui/material';
 import ReplaySharpIcon from '@mui/icons-material/ReplaySharp';
 
 /**
@@ -64,19 +64,21 @@ export const EulaScreenBase: React.FC<EulaScreenProps> = (props) => {
                             height: '100%',
                         }}
                     >
-                        <IconButton onClick={onRefetch}>
-                            <ReplaySharpIcon color="primary" sx={{ width: 64, height: 64 }} />
-                        </IconButton>
-                        <Typography
+                        <Box
+                            sx={{
+                                flexDirection: 'column',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                cursor: 'pointer',
+                                p: 1,
+                            }}
                             onClick={onRefetch}
-                            color="primary"
-                            fontSize="30px"
-                            display="block"
-                            fontWeight={600}
-                            sx={{ cursor: 'pointer' }}
                         >
-                            Retry
-                        </Typography>
+                            <ReplaySharpIcon color="primary" sx={{ width: 36, height: 36 }} />
+                            <Typography variant="subtitle2" color="primary">
+                                Retry
+                            </Typography>
+                        </Box>
                     </Box>
                 ) : htmlEula ? (
                     <Box

--- a/login-workflow/src/screens/EulaScreen/EulaScreenBase.tsx
+++ b/login-workflow/src/screens/EulaScreen/EulaScreenBase.tsx
@@ -54,7 +54,7 @@ export const EulaScreenBase: React.FC<EulaScreenProps> = (props) => {
         <WorkflowCard {...cardBaseProps}>
             <WorkflowCardHeader {...headerProps} />
             <WorkflowCardBody>
-                {checkboxProps.disabled ? (
+                {checkboxProps?.disabled ? (
                     <Box
                         sx={{
                             display: 'flex',

--- a/login-workflow/src/screens/EulaScreen/EulaScreenBase.tsx
+++ b/login-workflow/src/screens/EulaScreen/EulaScreenBase.tsx
@@ -61,16 +61,16 @@ export const EulaScreenBase: React.FC<EulaScreenProps> = (props) => {
                     />
                 )} */}
                 {checkboxProps.disabled ? (
-                    <Button variant="outlined" color="primary" onClick={onRefetch}>
+                    <Button variant="outlined" color="primary" onClick={onRefetch} sx={{ mt: 'auto', mb: '50%' }}>
                         Refetch
                     </Button>
                 ) : htmlEula ? (
                     <Box
-                        sx={{ flex: '1 1 0px', overflow: 'auto' }}
+                        sx={{ flex: '1 1 0', overflow: 'auto' }}
                         dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(eulaContent as string) }}
                     />
                 ) : (
-                    <Box sx={{ flex: '1 1 0px', overflow: 'auto' }}>{eulaContent}</Box>
+                    <Box sx={{ flex: '1 1 0', overflow: 'auto' }}>{eulaContent}</Box>
                 )}
                 <ErrorManager {...errorDisplayConfig}>
                     <FormControlLabel

--- a/login-workflow/src/screens/EulaScreen/types.ts
+++ b/login-workflow/src/screens/EulaScreen/types.ts
@@ -23,4 +23,7 @@ export type EulaScreenProps = WorkflowCardProps & {
 
     // used to configure how errors are rendered
     errorDisplayConfig?: ErrorManagerProps;
+
+    // called when refetch button clicked
+    onRefetch?: () => void;
 };

--- a/login-workflow/src/screens/ForgotPasswordScreen/ForgotPasswordScreen.test.tsx
+++ b/login-workflow/src/screens/ForgotPasswordScreen/ForgotPasswordScreen.test.tsx
@@ -196,8 +196,8 @@ describe('Forgot Password Screen tests', () => {
         expect(screen.getByText(/Submit/i)).toBeEnabled();
         fireEvent.click(nextButton);
 
-        const successMessage = screen.findByText('Success');
-        await (() => expect(successMessage).toBeInTheDocument());
+        const successMessage = await screen.findByText('Success');
+        expect(successMessage).toBeInTheDocument();
     });
 
     it('should show loader, when loading prop is passed to WorkflowCardBaseProps', () => {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #4498 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Added button for refetching the EULA when app fails to fetch EULA 

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)
<img width="1440" alt="Screenshot 2023-08-22 at 1 00 58 PM" src="https://github.com/etn-ccis/blui-react-workflows/assets/130662346/2c5db6c5-ebb2-4cfc-9647-a1bd9d67ebc4">

#### To Test:

- yarn start:example

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
