### PR TITLE
Feature/4595 - Implement show / hide functionality for change password

### DIFF
--- a/login-workflow/example/src/screens/ExampleHome.tsx
+++ b/login-workflow/example/src/screens/ExampleHome.tsx
@@ -30,7 +30,7 @@ import { useNavigate } from 'react-router-dom';
 import * as Colors from '@brightlayer-ui/colors';
 import FormControl from '@mui/material/FormControl';
 import { MenuItem, Select, SelectChangeEvent } from '@mui/material';
-import { ChangePasswordDialog } from '@brightlayer-ui/react-auth-workflow';
+import { useAuthContext } from '@brightlayer-ui/react-auth-workflow';
 import i18n from '../translations/i18n';
 export const ExampleHome: React.FC<React.PropsWithChildren> = () => {
     const app = useApp();
@@ -39,7 +39,7 @@ export const ExampleHome: React.FC<React.PropsWithChildren> = () => {
     const [open, setOpen] = useState(false);
     const navigate = useNavigate();
     const theme = useTheme();
-    const [openDialog, setOpenDialog] = React.useState(false);
+    const { showPasswordDialog } = useAuthContext();
 
     const containerStyles = {
         width: '100%',
@@ -151,7 +151,7 @@ export const ExampleHome: React.FC<React.PropsWithChildren> = () => {
                                                 icon: <LockIcon />,
                                                 title: `${t('USER_MENU.CHANGE_PASSWORD')}`,
                                                 onClick: (): any => {
-                                                    setOpenDialog(true);
+                                                    showPasswordDialog(true);
                                                 },
                                             },
                                             {
@@ -178,7 +178,6 @@ export const ExampleHome: React.FC<React.PropsWithChildren> = () => {
                     />
                 </Box>
             </DrawerLayout>
-            <ChangePasswordDialog open={openDialog} />
         </>
     );
 };

--- a/login-workflow/src/components/ChangePasswordDialog/ChangePasswordDialog.tsx
+++ b/login-workflow/src/components/ChangePasswordDialog/ChangePasswordDialog.tsx
@@ -9,12 +9,25 @@ export const ChangePasswordDialog: React.FC<ChangePasswordDialogProps> = (props)
     const { t } = useLanguageLocale();
     const passwordRef = useRef(null);
     const confirmRef = useRef(null);
+    const [currentInput, setCurrentInput] = useState('');
     const [passwordInput, setPasswordInput] = useState('');
     const [confirmInput, setConfirmInput] = useState('');
-    const [currentInput, setCurrentInput] = useState('');
     const [showErrorDialog, setShowErrorDialog] = useState(false);
     const [isLoading, setIsLoading] = useState(false);
     const { actions, navigate, routeConfig } = useAuthContext();
+
+    const {
+        open,
+        dialogTitle = t('bluiAuth:CHANGE_PASSWORD.PASSWORD'),
+        dialogDescription = t('bluiAuth:CHANGE_PASSWORD.PASSWORD_INFO'),
+        currentPasswordLabel = t('bluiCommon:LABELS.CURRENT_PASSWORD'),
+        previousLabel = t('bluiCommon:ACTIONS.BACK'),
+        nextLabel = t('bluiCommon:ACTIONS.OKAY'),
+        onPrevious,
+        onSubmit,
+        PasswordProps,
+        ErrorDialogProps,
+    } = props;
 
     const passwordRequirements = defaultPasswordRequirements(t);
 
@@ -34,25 +47,14 @@ export const ChangePasswordDialog: React.FC<ChangePasswordDialogProps> = (props)
             try {
                 setIsLoading(true);
                 await actions().changePassword(currentInput, passwordInput);
+                onSubmit();
             } catch {
                 setShowErrorDialog(true);
             } finally {
                 setIsLoading(false);
             }
         }
-    }, [checkPasswords, currentInput, passwordInput, actions, setIsLoading, setShowErrorDialog]);
-
-    const {
-        open,
-        dialogTitle = t('bluiAuth:CHANGE_PASSWORD.PASSWORD'),
-        dialogDescription = t('bluiAuth:CHANGE_PASSWORD.PASSWORD_INFO'),
-        currentPasswordLabel = t('bluiCommon:LABELS.CURRENT_PASSWORD'),
-        previousLabel = t('bluiCommon:ACTIONS.BACK'),
-        nextLabel = t('bluiCommon:ACTIONS.OKAY'),
-        onPrevious = (): void => navigate('/'),
-        PasswordProps,
-        ErrorDialogProps,
-    } = props;
+    }, [checkPasswords, currentInput, passwordInput, actions, setIsLoading, setShowErrorDialog, onSubmit]);
 
     const passwordProps = {
         newPasswordLabel: t('bluiAuth:CHANGE_PASSWORD.NEW_PASSWORD'),

--- a/login-workflow/src/components/Error/ErrorManager.tsx
+++ b/login-workflow/src/components/Error/ErrorManager.tsx
@@ -67,7 +67,7 @@ const ErrorManager: React.FC<ErrorManagerProps> = (props): JSX.Element => {
                 dismissButtonText={dismissLabel}
             />
         );
-    }, [dialogConfig, error, onClose]);
+    }, [dialogConfig, error, onClose, t]);
 
     const ErrorMessageBoxWithProps = useCallback((): JSX.Element => {
         const { dismissible = true, fontColor, backgroundColor, sx } = messageBoxConfig;

--- a/login-workflow/src/contexts/AuthContext/context.ts
+++ b/login-workflow/src/contexts/AuthContext/context.ts
@@ -5,4 +5,6 @@
 import { createContext } from 'react';
 import { AuthContextProviderProps } from './types';
 
-export const AuthContext = createContext<AuthContextProviderProps | null>(null);
+export const AuthContext = createContext<
+    (AuthContextProviderProps & { showPasswordDialog: (arg: boolean) => void }) | null
+>(null);

--- a/login-workflow/src/contexts/AuthContext/index.ts
+++ b/login-workflow/src/contexts/AuthContext/index.ts
@@ -12,7 +12,7 @@ import { AuthDictionaries } from './AuthDictionaries';
  * @private
  * @internal
  */
-export const useAuthContext = (): AuthContextProviderProps => {
+export const useAuthContext = (): AuthContextProviderProps & { showPasswordDialog: (arg: boolean) => void } => {
     const context = useContext(AuthContext);
     if (context === null) {
         throw new Error('useAuthContext must be used within AuthContextProvider');

--- a/login-workflow/src/contexts/AuthContext/provider.tsx
+++ b/login-workflow/src/contexts/AuthContext/provider.tsx
@@ -52,7 +52,7 @@ export const AuthContextProvider: React.FC<
             <AuthContext.Provider value={{ ...authContextProps, showPasswordDialog: setDialogOpen }}>
                 <ErrorContext.Provider value={errorConfig}>
                     {children}
-                    {PasswordDialog}
+                    {dialogOpen && PasswordDialog}
                 </ErrorContext.Provider>
             </AuthContext.Provider>
         </I18nextProvider>

--- a/login-workflow/src/contexts/AuthContext/provider.tsx
+++ b/login-workflow/src/contexts/AuthContext/provider.tsx
@@ -3,7 +3,7 @@
  * @module AuthContextProvider
  */
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { AuthContextProviderProps } from './types';
 import { AuthContext } from './context';
 import { I18nextProvider } from 'react-i18next';
@@ -11,10 +11,22 @@ import i18nAuthInstance from './i18nAuthInstance';
 import { ErrorContext } from '../ErrorContext';
 import { AuthDictionaries } from './AuthDictionaries';
 import { SharedDictionaries } from '../SharedDictionaries';
+import { ChangePasswordDialog } from '../../components';
 
-export const AuthContextProvider: React.FC<React.PropsWithChildren<AuthContextProviderProps>> = (props) => {
+export const AuthContextProvider: React.FC<
+    React.PropsWithChildren<AuthContextProviderProps & { PasswordDialog?: JSX.Element }>
+> = (props) => {
     const i18nInstance = props.i18n ?? i18nAuthInstance;
-    const { children, ...authContextProps } = props;
+    const [dialogOpen, setDialogOpen] = useState(false);
+
+    const hideDialog = (): void => setDialogOpen(false);
+
+    const {
+        children,
+        PasswordDialog = <ChangePasswordDialog open={dialogOpen} onPrevious={hideDialog} onSubmit={hideDialog} />,
+        ...authContextProps
+    } = props;
+
     const { language, i18n = i18nInstance, errorConfig } = props;
 
     if (props.i18n) {
@@ -37,8 +49,11 @@ export const AuthContextProvider: React.FC<React.PropsWithChildren<AuthContextPr
 
     return (
         <I18nextProvider i18n={i18nInstance}>
-            <AuthContext.Provider value={authContextProps}>
-                <ErrorContext.Provider value={errorConfig}>{children}</ErrorContext.Provider>
+            <AuthContext.Provider value={{ ...authContextProps, showPasswordDialog: setDialogOpen }}>
+                <ErrorContext.Provider value={errorConfig}>
+                    {children}
+                    {PasswordDialog}
+                </ErrorContext.Provider>
             </AuthContext.Provider>
         </I18nextProvider>
     );


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #4595 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Added `showPasswordDialog` prop in the authContext to hide and show Change Password Dialog.

<!-- Include screenshots if they will help illustrate the changes in this PR -->

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- yarn start:example
- Do login and click on Change Password in home page 

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
