### PR TITLE
Bug/421 registration by invitation success screen has as unfinished sentences issue fixed

### DIFF
--- a/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/chinese.ts
+++ b/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/chinese.ts
@@ -23,6 +23,8 @@ const resources: RegistrationLanguageFile = {
                 '您已成功使用<b>{{email}}</b>注册了一个新账号。\n\n您的账号已被加入“<b>{{organization}}</b>”。',
             SUCCESS_MESSAGE_ALT:
                 '您已成功使用<1>{{email}}</1>注册了一个新账号。\n\n您的账号已被加入“<3>{{organization}}</3>”。',
+            SUCCESS_MESSAGE_ALT_WITHOUT_EMAIL_PROVIDED:
+                '您的帳戶已成功創建。\n\n您的账号已被加入“<3>{{organization}}</3>”。',
             SUCCESS_EXISTING: '您已成功建立账号。请使用您的伊顿账号邮箱和密码登录。',
             FAILURE_MESSAGE: '无法完成注册。请点击“继续”退出。',
             UNKNOWN_EMAIL: '未知邮箱地址',

--- a/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/english.ts
+++ b/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/english.ts
@@ -24,6 +24,8 @@ const resources: RegistrationLanguageFile = {
                 'Your account has been successfully created with the email <b>{{email}}</b>.\n\nYour account has already been added to the <b>{{organization}}</b> organization.',
             SUCCESS_MESSAGE_ALT:
                 'Your account has been successfully created with the email <1>{{email}}</1>.\n\nYour account has already been added to the <3>{{organization}}</3> organization.',
+            SUCCESS_MESSAGE_ALT_WITHOUT_EMAIL_PROVIDED:
+                'Your account has been successfully created.\n\nYour account has already been added to the <3>{{organization}}</3> organization.',
             SUCCESS_EXISTING:
                 'Your account has been successfully created. Please log in with your Eaton account email and password.',
             FAILURE_MESSAGE: 'We were unable to complete your registration. Press continue below to finish.',

--- a/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/french.ts
+++ b/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/french.ts
@@ -23,6 +23,8 @@ const resources: RegistrationLanguageFile = {
                 "Votre compte a été créé avec le courrier électronique <b>{{email}}</b>.\n\nVotre compte a déjà été ajouté à l'organisation <b>{{organization}}</b>.",
             SUCCESS_MESSAGE_ALT:
                 "Votre compte a été créé avec le courrier électronique <1>{{email}}</1>.\n\nVotre compte a déjà été ajouté à l'organisation <3>{{organization}}</3>.",
+            SUCCESS_MESSAGE_ALT_WITHOUT_EMAIL_PROVIDED:
+                "Votre compte à été créé avec succès.\n\nVotre compte a déjà été ajouté à l'organisation <3>{{organization}}</3>.",
             SUCCESS_EXISTING: `Votre compte à été créé avec succès. Veuillez vous connecter avec l'adresse e-mail et le mot de passe de votre compte Eaton.`,
             FAILURE_MESSAGE:
                 "Nous n'avons pas pu terminer votre inscription. Appuyez sur Continuer ci-dessous pour finir.",

--- a/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/portuguese.ts
+++ b/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/portuguese.ts
@@ -24,6 +24,8 @@ const resources: RegistrationLanguageFile = {
                 'A sua conta foi criada corretamente com o e-mail <b>{{email}}</b>.\n\nA sua conta já foi adicionada à organização <b>{{organization}}</b>.',
             SUCCESS_MESSAGE_ALT:
                 'A sua conta foi criada corretamente com o e-mail <1>{{email}}</1>.\n\nA sua conta já foi adicionada à organização <3>{{organization}}</3>.',
+            SUCCESS_MESSAGE_ALT_WITHOUT_EMAIL_PROVIDED:
+                'A Sua conta foi criada com sucesso.\n\nA sua conta já foi adicionada à organização <3>{{organization}}</3>.',
             SUCCESS_EXISTING:
                 'A sua conta foi criada corretamente. Por favor inicie sessão com o e-mail e palavra-passe da sua conta Eaton.',
             FAILURE_MESSAGE: 'Foi impossível concluir o seu registo. Clique em continuar para concluir.',

--- a/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/spanish.ts
+++ b/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/spanish.ts
@@ -24,6 +24,8 @@ const resources: RegistrationLanguageFile = {
                 'Su cuenta se ha creado correctamente con el correo electrónico <b> {{email}} </b>.\n\nTu cuenta ya se ha agregado a la organización <b> {{organization}} </b>.',
             SUCCESS_MESSAGE_ALT:
                 'Su cuenta se ha creado correctamente con el correo electrónico <1> {{email}} </1>.\n\nTu cuenta ya se ha agregado a la organización <3> {{organization}} </3>.',
+            SUCCESS_MESSAGE_ALT_WITHOUT_EMAIL_PROVIDED:
+                'Su cuenta ha sido creada satisfactoriamente.\n\nTu cuenta ya se ha agregado a la organización <3> {{organization}} </3>.',
             SUCCESS_EXISTING:
                 'Tu cuenta ha sido creada con éxito. Inicie sesión con el correo electrónico y la contraseña de su cuenta Eaton. ',
             FAILURE_MESSAGE: 'No pudimos completar su registro. Pulse continuar para terminar. ',

--- a/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/types.ts
+++ b/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/types.ts
@@ -18,6 +18,7 @@ export type RegistrationTranslations = {
         };
         SUCCESS_MESSAGE: string;
         SUCCESS_MESSAGE_ALT: string;
+        SUCCESS_MESSAGE_ALT_WITHOUT_EMAIL_PROVIDED: string;
         SUCCESS_EXISTING: string;
         FAILURE_MESSAGE: string;
         UNKNOWN_EMAIL: string;

--- a/login-workflow/src/screens/RegistrationSuccessScreen/RegistrationSuccessScreen.tsx
+++ b/login-workflow/src/screens/RegistrationSuccessScreen/RegistrationSuccessScreen.tsx
@@ -36,7 +36,7 @@ export const RegistrationSuccessScreen: React.FC<SuccessScreenProps> = (props) =
         messageTitle = `${t('bluiCommon:MESSAGES.WELCOME')}, ${firstName} ${lastName}!`,
         message = (
             <Typography variant="subtitle2">
-                <Trans i18nKey={'bluiRegistration:REGISTRATION.SUCCESS_MESSAGE_ALT'} values={{ email, organization }}>
+                <Trans i18nKey={email? 'bluiRegistration:REGISTRATION.SUCCESS_MESSAGE_ALT' : 'bluiRegistration:REGISTRATION.SUCCESS_MESSAGE_ALT_WITHOUT_EMAIL_PROVIDED'} values={{ email, organization }}>
                     Your account has successfully been created with the email <b>{email}</b> belonging to the
                     <b>{` ${String(organization)}`}</b> org.
                 </Trans>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #421  .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

-
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-Screenshot 1.  Registration by invite with email Provided
<img width="487" alt="Screenshot 2023-08-24 at 1 00 59 PM" src="https://github.com/etn-ccis/blui-react-workflows/assets/133086327/ea6a84e8-bdf6-4968-82a1-4f160370135b">


Screenshot 2.  Registration by invite without email Provided
<img width="487" alt="Screenshot 2023-08-24 at 1 01 53 PM" src="https://github.com/etn-ccis/blui-react-workflows/assets/133086327/5f438ce3-97b6-4f9a-b7fc-6766f891475d">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- yarn start:example

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

- Fixed unfinished sentences and done all translations.
