### PR TITLE
Remove "press continue below to finish" from failure message translation

### DIFF
--- a/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/chinese.ts
+++ b/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/chinese.ts
@@ -24,7 +24,7 @@ const resources: RegistrationLanguageFile = {
             SUCCESS_MESSAGE_ALT:
                 '您已成功使用<1>{{email}}</1>注册了一个新账号。\n\n您的账号已被加入“<3>{{organization}}</3>”。',
             SUCCESS_EXISTING: '您已成功建立账号。请使用您的伊顿账号邮箱和密码登录。',
-            FAILURE_MESSAGE: '无法完成注册。请点击“继续”退出。',
+            FAILURE_MESSAGE: '无法完成注册。',
             UNKNOWN_EMAIL: '未知邮箱地址',
             UNKNOWN_ORGANIZATION: '未知组织',
         },

--- a/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/english.ts
+++ b/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/english.ts
@@ -26,7 +26,7 @@ const resources: RegistrationLanguageFile = {
                 'Your account has been successfully created with the email <1>{{email}}</1>.\n\nYour account has already been added to the <3>{{organization}}</3> organization.',
             SUCCESS_EXISTING:
                 'Your account has been successfully created. Please log in with your Eaton account email and password.',
-            FAILURE_MESSAGE: 'We were unable to complete your registration. Press continue below to finish.',
+            FAILURE_MESSAGE: 'We were unable to complete your registration.',
             UNKNOWN_EMAIL: 'Unknown Email',
             UNKNOWN_ORGANIZATION: 'Unknown Organization',
         },

--- a/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/portuguese.ts
+++ b/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/portuguese.ts
@@ -26,7 +26,7 @@ const resources: RegistrationLanguageFile = {
                 'A sua conta foi criada corretamente com o e-mail <1>{{email}}</1>.\n\nA sua conta já foi adicionada à organização <3>{{organization}}</3>.',
             SUCCESS_EXISTING:
                 'A sua conta foi criada corretamente. Por favor inicie sessão com o e-mail e palavra-passe da sua conta Eaton.',
-            FAILURE_MESSAGE: 'Foi impossível concluir o seu registo. Clique em continuar para concluir.',
+            FAILURE_MESSAGE: 'Foi impossível concluir o seu registo.',
             UNKNOWN_EMAIL: 'E-mail desconhecido',
             UNKNOWN_ORGANIZATION: 'Organização desconhecida',
         },

--- a/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/spanish.ts
+++ b/login-workflow/src/contexts/RegistrationContext/RegistrationDictionaries/spanish.ts
@@ -26,7 +26,7 @@ const resources: RegistrationLanguageFile = {
                 'Su cuenta se ha creado correctamente con el correo electrónico <1> {{email}} </1>.\n\nTu cuenta ya se ha agregado a la organización <3> {{organization}} </3>.',
             SUCCESS_EXISTING:
                 'Tu cuenta ha sido creada con éxito. Inicie sesión con el correo electrónico y la contraseña de su cuenta Eaton. ',
-            FAILURE_MESSAGE: 'No pudimos completar su registro. Pulse continuar para terminar. ',
+            FAILURE_MESSAGE: 'No pudimos completar su registro. ',
             UNKNOWN_EMAIL: 'Correo electrónico desconocido',
             UNKNOWN_ORGANIZATION: 'Organización desconocida',
         },


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #422 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Remove "press continue below to finish" from failure message translation
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
