### PR TITLE
Fix onClose function merge issue for errorManager

### DIFF
--- a/login-workflow/example/src/screens/Login.tsx
+++ b/login-workflow/example/src/screens/Login.tsx
@@ -8,5 +8,12 @@ export const Login = (): JSX.Element => (
     <LoginScreen
         projectImage={<img src={EatonLogo} alt="logo" style={{ maxHeight: 80 }} />}
         header={<DebugComponent />}
+        errorDisplayConfig={{
+            mode: 'message-box',
+            messageBoxConfig: {
+                dismissible: true,
+                position: 'top',
+            },
+        }}
     />
 );

--- a/login-workflow/src/screens/AccountDetailsScreen/AccountDetailsScreen.tsx
+++ b/login-workflow/src/screens/AccountDetailsScreen/AccountDetailsScreen.tsx
@@ -34,7 +34,14 @@ export const AccountDetailsScreen: React.FC<AccountDetailsScreenProps> = (props)
     const [lastName, setLastName] = useState(screenData.AccountDetails.lastName);
     const [isLoading, setIsLoading] = useState(false);
     const { triggerError, errorManagerConfig } = useErrorManager();
-    const errorDisplayConfig = { ...errorManagerConfig, ...props.errorDisplayConfig };
+    const errorDisplayConfig = {
+        ...errorManagerConfig,
+        ...props.errorDisplayConfig,
+        onClose: () => {
+            if (props.errorDisplayConfig && props.errorDisplayConfig.onClose) props.errorDisplayConfig.onClose();
+            if (errorManagerConfig.onClose) errorManagerConfig?.onClose();
+        },
+    };
 
     const onNext = useCallback(async (): Promise<void> => {
         try {

--- a/login-workflow/src/screens/AccountDetailsScreen/AccountDetailsScreen.tsx
+++ b/login-workflow/src/screens/AccountDetailsScreen/AccountDetailsScreen.tsx
@@ -37,7 +37,7 @@ export const AccountDetailsScreen: React.FC<AccountDetailsScreenProps> = (props)
     const errorDisplayConfig = {
         ...errorManagerConfig,
         ...props.errorDisplayConfig,
-        onClose: () => {
+        onClose: (): void => {
             if (props.errorDisplayConfig && props.errorDisplayConfig.onClose) props.errorDisplayConfig.onClose();
             if (errorManagerConfig.onClose) errorManagerConfig?.onClose();
         },

--- a/login-workflow/src/screens/CreateAccountScreen/CreateAccountScreen.tsx
+++ b/login-workflow/src/screens/CreateAccountScreen/CreateAccountScreen.tsx
@@ -33,7 +33,14 @@ export const CreateAccountScreen: React.FC<CreateAccountScreenProps> = (props) =
     const [emailInputValue, setEmailInputValue] = useState(screenData.CreateAccount.emailAddress);
     const [isLoading, setIsLoading] = useState(false);
     const { triggerError, errorManagerConfig } = useErrorManager();
-    const errorDisplayConfig = { ...errorManagerConfig, ...props.errorDisplayConfig };
+    const errorDisplayConfig = {
+        ...errorManagerConfig,
+        ...props.errorDisplayConfig,
+        onClose: () => {
+            if (props.errorDisplayConfig && props.errorDisplayConfig.onClose) props.errorDisplayConfig.onClose();
+            if (errorManagerConfig.onClose) errorManagerConfig?.onClose();
+        },
+    };
 
     const onNext = useCallback(async () => {
         try {

--- a/login-workflow/src/screens/CreateAccountScreen/CreateAccountScreen.tsx
+++ b/login-workflow/src/screens/CreateAccountScreen/CreateAccountScreen.tsx
@@ -36,7 +36,7 @@ export const CreateAccountScreen: React.FC<CreateAccountScreenProps> = (props) =
     const errorDisplayConfig = {
         ...errorManagerConfig,
         ...props.errorDisplayConfig,
-        onClose: () => {
+        onClose: (): void => {
             if (props.errorDisplayConfig && props.errorDisplayConfig.onClose) props.errorDisplayConfig.onClose();
             if (errorManagerConfig.onClose) errorManagerConfig?.onClose();
         },

--- a/login-workflow/src/screens/CreatePasswordScreen/CreatePasswordScreen.tsx
+++ b/login-workflow/src/screens/CreatePasswordScreen/CreatePasswordScreen.tsx
@@ -40,7 +40,14 @@ export const CreatePasswordScreen: React.FC<CreatePasswordScreenProps> = (props)
     const [isLoading, setIsLoading] = useState(false);
     const passwordRequirements = defaultPasswordRequirements(t);
     const { triggerError, errorManagerConfig } = useErrorManager();
-    const errorDisplayConfig = { ...errorManagerConfig, ...props.errorDisplayConfig };
+    const errorDisplayConfig = {
+        ...errorManagerConfig,
+        ...props.errorDisplayConfig,
+        onClose: () => {
+            if (props.errorDisplayConfig && props.errorDisplayConfig.onClose) props.errorDisplayConfig.onClose();
+            if (errorManagerConfig.onClose) errorManagerConfig?.onClose();
+        },
+    };
 
     const onNext = useCallback(async (): Promise<void> => {
         try {

--- a/login-workflow/src/screens/CreatePasswordScreen/CreatePasswordScreen.tsx
+++ b/login-workflow/src/screens/CreatePasswordScreen/CreatePasswordScreen.tsx
@@ -43,7 +43,7 @@ export const CreatePasswordScreen: React.FC<CreatePasswordScreenProps> = (props)
     const errorDisplayConfig = {
         ...errorManagerConfig,
         ...props.errorDisplayConfig,
-        onClose: () => {
+        onClose: (): void => {
             if (props.errorDisplayConfig && props.errorDisplayConfig.onClose) props.errorDisplayConfig.onClose();
             if (errorManagerConfig.onClose) errorManagerConfig?.onClose();
         },

--- a/login-workflow/src/screens/EulaScreen/EulaScreen.tsx
+++ b/login-workflow/src/screens/EulaScreen/EulaScreen.tsx
@@ -27,7 +27,14 @@ export const EulaScreen: React.FC<EulaScreenProps> = (props) => {
     const { t } = useLanguageLocale();
     const { actions, navigate, routeConfig, language } = useRegistrationContext();
     const { triggerError, errorManagerConfig } = useErrorManager();
-    const errorDisplayConfig = { ...errorManagerConfig, ...props.errorDisplayConfig };
+    const errorDisplayConfig = {
+        ...errorManagerConfig,
+        ...props.errorDisplayConfig,
+        onClose: () => {
+            if (props.errorDisplayConfig && props.errorDisplayConfig.onClose) props.errorDisplayConfig.onClose();
+            if (errorManagerConfig.onClose) errorManagerConfig?.onClose();
+        },
+    };
     const regWorkflow = useRegistrationWorkflowContext();
     const { nextScreen, previousScreen, screenData, currentScreen, totalScreens, isInviteRegistration } = regWorkflow;
     const {
@@ -86,8 +93,6 @@ export const EulaScreen: React.FC<EulaScreenProps> = (props) => {
                 isAccountExist: isAccExist,
             });
         } catch (_error) {
-            console.error(_error);
-            console.error('Error while updating EULA acceptance...');
             triggerError(_error as Error);
         } finally {
             setIsLoading(false);

--- a/login-workflow/src/screens/EulaScreen/EulaScreen.tsx
+++ b/login-workflow/src/screens/EulaScreen/EulaScreen.tsx
@@ -30,7 +30,7 @@ export const EulaScreen: React.FC<EulaScreenProps> = (props) => {
     const errorDisplayConfig = {
         ...errorManagerConfig,
         ...props.errorDisplayConfig,
-        onClose: () => {
+        onClose: (): void => {
             if (props.errorDisplayConfig && props.errorDisplayConfig.onClose) props.errorDisplayConfig.onClose();
             if (errorManagerConfig.onClose) errorManagerConfig?.onClose();
         },

--- a/login-workflow/src/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
+++ b/login-workflow/src/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
@@ -33,7 +33,14 @@ export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props)
     const { t } = useLanguageLocale();
     const { actions, navigate, routeConfig } = useAuthContext();
     const { triggerError, errorManagerConfig } = useErrorManager();
-    const errorDisplayConfig = { ...errorManagerConfig, ...props.errorDisplayConfig };
+    const errorDisplayConfig = {
+        ...errorManagerConfig,
+        ...props.errorDisplayConfig,
+        onClose: () => {
+            if (props.errorDisplayConfig && props.errorDisplayConfig.onClose) props.errorDisplayConfig.onClose();
+            if (errorManagerConfig.onClose) errorManagerConfig?.onClose();
+        },
+    };
 
     const [emailInput, setEmailInput] = useState('');
     const [isLoading, setIsLoading] = useState(false);

--- a/login-workflow/src/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
+++ b/login-workflow/src/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
@@ -36,7 +36,7 @@ export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props)
     const errorDisplayConfig = {
         ...errorManagerConfig,
         ...props.errorDisplayConfig,
-        onClose: () => {
+        onClose: (): void => {
             if (props.errorDisplayConfig && props.errorDisplayConfig.onClose) props.errorDisplayConfig.onClose();
             if (errorManagerConfig.onClose) errorManagerConfig?.onClose();
         },

--- a/login-workflow/src/screens/LoginScreen/LoginScreen.tsx
+++ b/login-workflow/src/screens/LoginScreen/LoginScreen.tsx
@@ -50,7 +50,14 @@ export const LoginScreen: React.FC<React.PropsWithChildren<LoginScreenPropsPubli
     const auth = useAuthContext();
     const { actions, navigate, routeConfig, rememberMeDetails } = auth;
     const { triggerError, errorManagerConfig } = useErrorManager();
-    const errorDisplayConfig = { ...errorManagerConfig, ...props.errorDisplayConfig };
+    const errorDisplayConfig = {
+        ...errorManagerConfig,
+        ...props.errorDisplayConfig,
+        onClose: () => {
+            if (props.errorDisplayConfig && props.errorDisplayConfig.onClose) props.errorDisplayConfig.onClose();
+            if (errorManagerConfig.onClose) errorManagerConfig?.onClose();
+        },
+    };
 
     useEffect(() => {
         void actions().initiateSecurity();

--- a/login-workflow/src/screens/LoginScreen/LoginScreen.tsx
+++ b/login-workflow/src/screens/LoginScreen/LoginScreen.tsx
@@ -53,7 +53,7 @@ export const LoginScreen: React.FC<React.PropsWithChildren<LoginScreenPropsPubli
     const errorDisplayConfig = {
         ...errorManagerConfig,
         ...props.errorDisplayConfig,
-        onClose: () => {
+        onClose: (): void => {
             if (props.errorDisplayConfig && props.errorDisplayConfig.onClose) props.errorDisplayConfig.onClose();
             if (errorManagerConfig.onClose) errorManagerConfig?.onClose();
         },

--- a/login-workflow/src/screens/VerifyCodeScreen/VerifyCodeScreen.tsx
+++ b/login-workflow/src/screens/VerifyCodeScreen/VerifyCodeScreen.tsx
@@ -31,7 +31,14 @@ export const VerifyCodeScreen: React.FC<VerifyCodeScreenProps> = (props) => {
     const { nextScreen, previousScreen, screenData, currentScreen, totalScreens } = regWorkflow;
     const { emailAddress } = screenData.CreateAccount;
     const { triggerError, errorManagerConfig } = useErrorManager();
-    const errorDisplayConfig = { ...errorManagerConfig, ...props.errorDisplayConfig };
+    const errorDisplayConfig = {
+        ...errorManagerConfig,
+        ...props.errorDisplayConfig,
+        onClose: () => {
+            if (props.errorDisplayConfig && props.errorDisplayConfig.onClose) props.errorDisplayConfig.onClose();
+            if (errorManagerConfig.onClose) errorManagerConfig?.onClose();
+        },
+    };
 
     const [verifyCode, setVerifyCode] = useState(screenData.VerifyCode.code);
     const [isLoading, setIsLoading] = useState(false);

--- a/login-workflow/src/screens/VerifyCodeScreen/VerifyCodeScreen.tsx
+++ b/login-workflow/src/screens/VerifyCodeScreen/VerifyCodeScreen.tsx
@@ -34,7 +34,7 @@ export const VerifyCodeScreen: React.FC<VerifyCodeScreenProps> = (props) => {
     const errorDisplayConfig = {
         ...errorManagerConfig,
         ...props.errorDisplayConfig,
-        onClose: () => {
+        onClose: (): void => {
             if (props.errorDisplayConfig && props.errorDisplayConfig.onClose) props.errorDisplayConfig.onClose();
             if (errorManagerConfig.onClose) errorManagerConfig?.onClose();
         },


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes BLUI-4570

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Fix onClose function merge issue for ErrorManager

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Update the AppRouter to use an onClose method for the errorDisplayConfig on each screen in the workflow.
- e.g.,
```
 <Route
                    path={'/self-registration'}
                    element={
                        <RegistrationWorkflow>
                            <EulaScreen
                                errorDisplayConfig={{
                                    mode: 'message-box',
                                    onClose: () => console.log('closing eula screen error...'),
                                }}
                            />
                            <VerifyCodeScreen
                                errorDisplayConfig={{
                                    mode: 'message-box',
                                    onClose: () => console.log('closing verify code screen error...'),
                                }}
                            />
                            <CreatePasswordScreen
                                errorDisplayConfig={{
                                    mode: 'dialog',
                                    onClose: () => console.log('closing create password screen error...'),
                                }}
                            />
                            <AccountDetailsScreen
                                errorDisplayConfig={{
                                    mode: 'message-box',
                                    onClose: () => console.log('closing account details error...'),
                                }}
                            />
                        </RegistrationWorkflow>
                    }
                />
```
- Update the registration UI actions to throw an error for each screen to test this out. e.g., 
```
 acceptEula: async (): Promise<void> => {
        throw new Error('Sorry, there was a problem sending your request.');
    },
```
- Ensure the dialog and/or message -box closes as well as calls the passed-in onClose method

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
