### PR TITLE
Blui 4562 cosmetic issues

### DIFF
--- a/login-workflow/src/components/ChangePasswordDialog/ChangePasswordDialogBase.tsx
+++ b/login-workflow/src/components/ChangePasswordDialog/ChangePasswordDialogBase.tsx
@@ -88,14 +88,17 @@ export const ChangePasswordDialogBase: React.FC<ChangePasswordDialogProps> = (pr
                     display: 'flex',
                     flexDirection: 'column',
                     pt: 2,
-                    px: { md: 3, sm: 2 },
-                    pb: { md: 2, sm: 3 },
+                    pb: { xs: 2, md: 3 },
+                    px: { xs: 2, md: 3 },
                 }}
             >
                 <Typography>{dialogDescription}</Typography>
                 <Divider sx={{ mt: 5, mb: 4, mx: { md: -3, xs: -2 } }} />
                 <SetPassword {...PasswordProps}>
                     <PasswordTextField
+                        sx={{
+                            mb: { xs: 3, md: 4 },
+                        }}
                         id="current-password"
                         label={currentPasswordLabel}
                         value={currentPassword}

--- a/login-workflow/src/components/SetPassword/SetPassword.tsx
+++ b/login-workflow/src/components/SetPassword/SetPassword.tsx
@@ -85,7 +85,6 @@ export const SetPassword: React.FC<React.PropsWithChildren<SetPasswordProps>> = 
                 label={newPasswordLabel}
                 value={passwordInput}
                 onChange={(evt: ChangeEvent<HTMLInputElement>): void => onPassChange(evt.target.value)}
-                sx={TextFieldStyles(theme)}
                 onKeyUp={(e): void => {
                     if (e.key === 'Enter' && confirmRef.current) {
                         confirmRef.current.focus();

--- a/login-workflow/src/components/WorkflowCard/WorkflowCardActions.tsx
+++ b/login-workflow/src/components/WorkflowCard/WorkflowCardActions.tsx
@@ -74,7 +74,7 @@ export const WorkflowCardActions: React.FC<WorkflowCardActionsProps> = (props) =
 
             <CardActions
                 sx={[
-                    { flexDirection: 'column', justifyContent: 'flex-end', p: { xs: 2, sm: 2, md: 3 } },
+                    { flexDirection: 'column', justifyContent: 'flex-end', p: { xs: 2, md: 3 } },
                     ...(Array.isArray(sx) ? sx : [sx]),
                 ]}
                 className={defaultClasses.root}

--- a/login-workflow/src/components/WorkflowCard/WorkflowCardBody.tsx
+++ b/login-workflow/src/components/WorkflowCard/WorkflowCardBody.tsx
@@ -20,8 +20,8 @@ export const WorkflowCardBody: React.FC<CardContentProps> = (props) => {
                 overflow: 'auto',
                 flexDirection: 'column',
                 pt: 0,
-                pb: { sm: 3, md: 2 },
-                px: { sm: 2, md: 3 },
+                pb: { sm: 2, md: 3 },
+                px: { xs: 2, md: 3 },
                 ...sx,
             }}
             {...otherCardContentProps}

--- a/login-workflow/src/components/WorkflowFinishState.tsx
+++ b/login-workflow/src/components/WorkflowFinishState.tsx
@@ -39,6 +39,7 @@ export const WorkflowFinishState: React.FC<React.PropsWithChildren<React.PropsWi
                 }}
                 sx={{
                     color: 'inherit',
+                    p: 0,
                 }}
             />
         </Box>

--- a/login-workflow/src/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
+++ b/login-workflow/src/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
@@ -106,7 +106,7 @@ export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props)
                     <Typography component="a" href={`tel:${contactPhone}`} sx={LinkStyles}>
                         {contactPhone}
                     </Typography>
-                    .
+                    {'.'}
                 </Trans>
             </Typography>
         ),
@@ -155,12 +155,21 @@ export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props)
                             icon={<CheckCircle color={'primary'} sx={{ fontSize: 100, mb: 5 }} />}
                             messageTitle={t('bluiCommon:MESSAGES.EMAIL_SENT')}
                             message={
-                                <Trans
-                                    i18nKey={'bluiAuth:FORGOT_PASSWORD.LINK_SENT_ALT'}
-                                    values={{ email: emailInput }}
+                                <Box
+                                    sx={{
+                                        overflow: 'hidden',
+                                        whiteSpace: 'normal',
+                                        wordBreak: 'break-word',
+                                    }}
+                                    component={'span'}
                                 >
-                                    Link has been sent to <b>{emailInput}</b>.
-                                </Trans>
+                                    <Trans
+                                        i18nKey={'bluiAuth:FORGOT_PASSWORD.LINK_SENT_ALT'}
+                                        values={{ email: emailInput }}
+                                    >
+                                        Link has been sent to <b>{emailInput}</b>.
+                                    </Trans>
+                                </Box>
                             }
                             {...slotProps.SuccessScreen}
                             WorkflowCardHeaderProps={{

--- a/login-workflow/src/screens/LoginScreen/LoginScreen.tsx
+++ b/login-workflow/src/screens/LoginScreen/LoginScreen.tsx
@@ -107,7 +107,7 @@ export const LoginScreen: React.FC<React.PropsWithChildren<LoginScreenPropsPubli
             usernameValidator={usernameValidator}
             initialUsernameValue={initialUsernameValue}
             passwordLabel={passwordLabel}
-            passwordTextFieldProps={{ required: true, ...passwordTextFieldProps }}
+            passwordTextFieldProps={passwordTextFieldProps}
             passwordValidator={(password: string): string | boolean => {
                 if (password.length < 1) {
                     return passwordRequiredValidatorText;


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes BLUI-4652 & BLUI-4680 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Screen: Login
Problem: The password field has an asterisk sign in the text field label.
Expect: The field should not contain an asterisk since all fields in the form are required.

- Screen: Registration-by-invitation - create new password
Problem: extra undesired margin above the first text field "password"
Expect: the distance between the divider and the "password" field should be 32px.

- Screen: Forgot password - Forgot password success
Problem: Undesired new line.

- enhance the forgot password success screen to have ability to contain a long email address if needed 


<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

-

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
