### PR TITLE
Moved existing acount success logic on load for invite registration

### DIFF
--- a/login-workflow/src/components/ChangePasswordDialog/ChangePasswordDialog.tsx
+++ b/login-workflow/src/components/ChangePasswordDialog/ChangePasswordDialog.tsx
@@ -47,7 +47,6 @@ export const ChangePasswordDialog: React.FC<ChangePasswordDialogProps> = (props)
         previousLabel = t('bluiCommon:ACTIONS.BACK'),
         nextLabel = t('bluiCommon:ACTIONS.OKAY'),
         onPrevious,
-        onSubmit,
         onFinish,
         PasswordProps,
         ErrorDialogProps,
@@ -88,7 +87,6 @@ export const ChangePasswordDialog: React.FC<ChangePasswordDialogProps> = (props)
         actions,
         setIsLoading,
         setShowErrorDialog,
-        onSubmit,
         onFinish,
         props.showSuccessScreen,
     ]);

--- a/login-workflow/src/components/RegistrationWorkflow/RegistrationWorkflow.tsx
+++ b/login-workflow/src/components/RegistrationWorkflow/RegistrationWorkflow.tsx
@@ -166,6 +166,18 @@ export const RegistrationWorkflow: React.FC<React.PropsWithChildren<Registration
         if (isInviteRegistration) {
             const params = parseQueryString(window.location.search);
 
+            let isAccExist;
+            void (async (): Promise<void> => {
+                try {
+                    isAccExist = await actions.validateUserRegistrationRequest(params.code, params.email);
+                } catch (_error) {
+                    triggerError(_error as Error);
+                } finally {
+                    setIsAccountExist(isAccExist);
+                    setShowSuccessScreen(isAccExist);
+                }
+            })();
+
             updateScreenData({ screenId: 'CreateAccount', values: { emailAddress: params.email } });
             updateScreenData({ screenId: 'VerifyCode', values: { code: params.code } });
         }

--- a/login-workflow/src/screens/EulaScreen/EulaScreen.tsx
+++ b/login-workflow/src/screens/EulaScreen/EulaScreen.tsx
@@ -36,7 +36,7 @@ export const EulaScreen: React.FC<EulaScreenProps> = (props) => {
         },
     };
     const regWorkflow = useRegistrationWorkflowContext();
-    const { nextScreen, previousScreen, screenData, currentScreen, totalScreens, isInviteRegistration } = regWorkflow;
+    const { nextScreen, previousScreen, screenData, currentScreen, totalScreens } = regWorkflow;
     const {
         WorkflowCardHeaderProps,
         WorkflowCardActionsProps,
@@ -79,24 +79,16 @@ export const EulaScreen: React.FC<EulaScreenProps> = (props) => {
             if (screenData.Eula.accepted) {
                 await actions.acceptEula?.();
             }
-            let isAccExist;
-            if (isInviteRegistration) {
-                isAccExist = await actions.validateUserRegistrationRequest(
-                    screenData.VerifyCode.code,
-                    screenData.CreateAccount.emailAddress
-                );
-            }
             void nextScreen({
                 screenId: 'Eula',
                 values: { accepted: screenData.Eula.accepted },
-                isAccountExist: isAccExist,
             });
         } catch (_error) {
             triggerError(_error as Error);
         } finally {
             setIsLoading(false);
         }
-    }, [actions, nextScreen, triggerError, isInviteRegistration, screenData]);
+    }, [actions, nextScreen, triggerError, screenData]);
 
     const onPrevious = useCallback((): void => {
         setIsLoading(true);


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # BLUI-4709

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:
- Added existing account success screen on load for invite registration
- Fixed lint issues

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

<img width="1792" alt="Screenshot 2023-09-12 at 8 45 58 PM" src="https://github.com/etn-ccis/blui-react-workflows/assets/120575281/28a9d699-3fdb-4d76-b518-cd65645bdf3f">

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- cd login-workflow
- yarn start:example
- click on Debug button
- Click in Test Invite Register link

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
