### PR TITLE
React Workflows - Homepage after logged In in mobile view has drawer always open

### DIFF
--- a/login-workflow/example/src/screens/ExampleHome.tsx
+++ b/login-workflow/example/src/screens/ExampleHome.tsx
@@ -80,7 +80,7 @@ export const ExampleHome: React.FC<React.PropsWithChildren> = () => {
         <>
             <DrawerLayout
                 drawer={
-                    <Drawer open={true} width={332} variant={'persistent'}>
+                    <Drawer open={open} width={332} variant={'persistent'}>
                         <DrawerHeader
                             title={`${t('DRAWER_MENU.TITLE')}`}
                             icon={<Menu />}
@@ -106,7 +106,7 @@ export const ExampleHome: React.FC<React.PropsWithChildren> = () => {
                 <Box>
                     <AppBar color="primary">
                         <Toolbar sx={{ px: 2, minHeight: 'unset', height: '4rem' }}>
-                            <Typography variant="h6">{`${t('TOOLBAR_MENU.HOME_PAGE')}`}</Typography>
+                            <Typography variant="h6" sx={{ pl: '40px' }}>{`${t('TOOLBAR_MENU.HOME_PAGE')}`}</Typography>
                             <Spacer />
                             <Box sx={{ py: 2 }}>
                                 <FormControl fullWidth>
@@ -116,7 +116,6 @@ export const ExampleHome: React.FC<React.PropsWithChildren> = () => {
                                         variant={'standard'}
                                         sx={{
                                             padding: '4px',
-                                            minWidth: '160px',
                                             margin: '16px',
                                             backgroundColor: 'transparent',
                                             color: Colors.white[50],


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #BLUI-4711 .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Added state to the Home page Drawer.
- Added style changes.

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)
<img width="1190" alt="Screenshot 2023-09-22 at 10 50 59 AM" src="https://github.com/etn-ccis/blui-react-workflows/assets/130662346/2a2cfa87-d91f-463c-82b3-43fef91c703b">


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- yarn start:example
- Login to the application

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
