### PR TITLE
Fix ResetPasswordScreen error configuration

### DIFF
--- a/login-workflow/src/screens/ResetPasswordScreen/ResetPasswordScreen.tsx
+++ b/login-workflow/src/screens/ResetPasswordScreen/ResetPasswordScreen.tsx
@@ -32,6 +32,14 @@ export const ResetPasswordScreen: React.FC<ResetPasswordScreenProps> = (props) =
     const passwordRef = useRef(null);
     const confirmRef = useRef(null);
     const { triggerError, errorManagerConfig } = useErrorManager();
+    const errorDisplayConfig = {
+        ...errorManagerConfig,
+        ...props.errorDisplayConfig,
+        onClose: (): void => {
+            if (props.errorDisplayConfig && props.errorDisplayConfig.onClose) props.errorDisplayConfig.onClose();
+            if (errorManagerConfig.onClose) errorManagerConfig?.onClose();
+        },
+    };
 
     const {
         WorkflowCardBaseProps,
@@ -39,7 +47,6 @@ export const ResetPasswordScreen: React.FC<ResetPasswordScreenProps> = (props) =
         WorkflowCardInstructionProps,
         WorkflowCardActionsProps,
         PasswordProps,
-        errorDisplayConfig = errorManagerConfig,
         slots = {},
         slotProps = {},
     } = props;

--- a/login-workflow/src/screens/ResetPasswordScreen/ResetPasswordScreen.tsx
+++ b/login-workflow/src/screens/ResetPasswordScreen/ResetPasswordScreen.tsx
@@ -155,6 +155,8 @@ export const ResetPasswordScreen: React.FC<ResetPasswordScreenProps> = (props) =
         passwordRef,
         confirmRef,
         ...PasswordProps,
+        initialNewPasswordValue: passwordInput,
+        initialConfirmPasswordValue: confirmInput,
         onPasswordChange: (passwordData: { password: string; confirm: string }): void => {
             updateFields(passwordData);
             PasswordProps?.onPasswordChange?.(passwordData);


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Fix error manager config in ResetPasswordScreen
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- Add test code in AppRouter 
<ResetPasswordScreen errorDisplayConfig={{
                                messageBoxConfig: {
                                    backgroundColor: 'green',
                                    dismissible: true,
                                    position: 'bottom'
                                },
                                mode: 'message-box'
                            }}/>

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
