### PR TITLE
Update jest to use max workers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
           name: Tests
           command: |
             cd login-workflow
-            yarn test --coverage --watchAll=false
+            yarn test:ci --coverage --watchAll=false
 
   build_login_workflow:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
           name: Tests
           command: |
             cd login-workflow
-            yarn test --maxWorkers=2 --coverage --watchAll=false
+            yarn test --coverage --watchAll=false
 
   build_login_workflow:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
           name: Tests
           command: |
             cd login-workflow
-            yarn test:ci --coverage --watchAll=false
+            yarn test:ci  --maxWorkers=2 --coverage --watchAll=false
 
   build_login_workflow:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,6 +73,7 @@ jobs:
   store_test_results:
     docker:
       - image: cimg/node:18.17.0-browsers
+    parallelism: 4
     working_directory: ~/login-workflow
     resource_class: large
     steps:

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "install:dependencies": "cd example && yarn && cd .. && yarn",
         "test": "jest --maxWorkers=50%",
-        "test:ci":"jest",
+        "test:ci": "jest",
         "build": "tsc --p tsconfig.lib.json && cp -r src/assets/. dist/assets && cp -r src/index.css dist/index.css",
         "link:workflow": "bash ./scripts/linkWorkflow.sh",
         "lint": "eslint \"src/**/**.{tsx,ts}\"",

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -8,6 +8,7 @@
     "scripts": {
         "install:dependencies": "cd example && yarn && cd .. && yarn",
         "test": "jest --maxWorkers=50%",
+        "test:ci":"jest --runInBand",
         "build": "tsc --p tsconfig.lib.json && cp -r src/assets/. dist/assets && cp -r src/index.css dist/index.css",
         "link:workflow": "bash ./scripts/linkWorkflow.sh",
         "lint": "eslint \"src/**/**.{tsx,ts}\"",

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -7,7 +7,7 @@
     "main": "dist/index.js",
     "scripts": {
         "install:dependencies": "cd example && yarn && cd .. && yarn",
-        "test": "jest",
+        "test": "jest --maxWorkers=50%",
         "build": "tsc --p tsconfig.lib.json && cp -r src/assets/. dist/assets && cp -r src/index.css dist/index.css",
         "link:workflow": "bash ./scripts/linkWorkflow.sh",
         "lint": "eslint \"src/**/**.{tsx,ts}\"",

--- a/login-workflow/package.json
+++ b/login-workflow/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "install:dependencies": "cd example && yarn && cd .. && yarn",
         "test": "jest --maxWorkers=50%",
-        "test:ci":"jest --runInBand",
+        "test:ci":"jest",
         "build": "tsc --p tsconfig.lib.json && cp -r src/assets/. dist/assets && cp -r src/index.css dist/index.css",
         "link:workflow": "bash ./scripts/linkWorkflow.sh",
         "lint": "eslint \"src/**/**.{tsx,ts}\"",


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- use yarn test:ci for circle ci and use parallelism: 4
- use yarn test --maxWorkers=50% for running tests locally.

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)
- parallelism: 4 only for test job (saves about 1 minute to run tests)
![image](https://github.com/etn-ccis/blui-react-workflows/assets/119693939/cca2f20a-f132-457d-9543-1442dd473595)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- checkout dev branch & yarn install:dependencies
- run yarn test and note time taken to complete tests
- git checkout feature/use-max-workers
- run yarn test and note time taken to complete tests

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
