### PR TITLE
Set password margin style fix

### DIFF
--- a/login-workflow/src/components/SetPassword/SetPassword.tsx
+++ b/login-workflow/src/components/SetPassword/SetPassword.tsx
@@ -111,7 +111,7 @@ export const SetPassword: React.FC<React.PropsWithChildren<SetPasswordProps>> = 
             />
             {passwordRequirements && passwordRequirements.length > 0 && (
                 <PasswordRequirements
-                    sx={{ mt: 2 }}
+                    sx={{ mt: { xs: 2 }, mb: { xs: 2 } }}
                     passwordText={passwordInput}
                     passwordRequirements={passwordRequirements}
                 />
@@ -122,9 +122,6 @@ export const SetPassword: React.FC<React.PropsWithChildren<SetPasswordProps>> = 
                 name="confirm"
                 inputRef={confirmRef}
                 label={confirmPasswordLabel}
-                sx={{
-                    mt: { md: 4, sm: 3 },
-                }}
                 value={confirmInput}
                 error={hasConfirmPasswordError()}
                 helperText={hasConfirmPasswordError() ? passwordNotMatchError : ''}


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #SetPassword margin fix .

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Added marginTop and marginBottom to the PasswordRequirements in SetPassword component

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)
<img width="1189" alt="Screenshot 2023-10-03 at 1 23 17 PM" src="https://github.com/etn-ccis/blui-react-workflows/assets/130662346/aa57afd9-7e68-4738-aaea-7002f8b63a87">


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- yarn start:example
- Check on CreatePasswordScreen, ResetPasswordScreen and ChangePasswordDialog.

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
