### PR TITLE
Fix showSuccessScreen prop when set to false

### DIFF
--- a/login-workflow/src/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
+++ b/login-workflow/src/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
@@ -52,7 +52,11 @@ export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props)
             try {
                 setIsLoading(true);
                 await actions.forgotPassword(email);
-                setShowSuccessScreen(true);
+                if (props.showSuccessScreen === false) {
+                    navigate(routeConfig.LOGIN as string);
+                } else {
+                    setShowSuccessScreen(true);
+                }
             } catch (_error) {
                 triggerError(_error as Error);
             } finally {


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # .
- **Fix showSuccessScreen prop when set to false**
<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Show login screen when showSuccessScreen prop set to false
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- [Oct-03-2023 16-01-51](https://github.com/etn-ccis/blui-react-workflows/assets/133877691/5ef4be3b-bd64-4a20-9ddd-e7d2e3e7238f)

<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:
- Update AppRouter.tsx `<ForgotPasswordScreen showSuccessScreen={false}/>`
- http://localhost:3000/forgot-password 
- enter an email address and click on next.


<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
