### PR TITLE
Blui 4933 error translations

### DIFF
--- a/login-workflow/CHANGELOG.md
+++ b/login-workflow/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v4.0.1 (Unreleased)
+
+### Fixed
+
+-   Translations not working while throwing error from actions ([#513](https://github.com/etn-ccis/blui-react-workflows/issues/513)).
+-   Error in the dialog / message box does not translate ([#510](https://github.com/etn-ccis/blui-react-workflows/issues/510)).
+-   Title missing in the messageBoxConfig of ErrorManager ([#507](https://github.com/etn-ccis/blui-react-workflows/issues/507)).
+
 ## v4.0.0 (October 4, 2023)
 
 ### Added

--- a/login-workflow/example/src/actions/AuthUIActions.tsx
+++ b/login-workflow/example/src/actions/AuthUIActions.tsx
@@ -11,7 +11,7 @@ function getRandomInt(max: number): number {
 
 function isRandomFailure(): boolean {
     const randomResponseNumber = getRandomInt(100);
-    return true; // randomResponseNumber < 10;
+    return false; // randomResponseNumber < 10;
 }
 
 type AuthUIActionsWithApp = (appHelper: AppContextType) => AuthUIActions;

--- a/login-workflow/example/src/actions/AuthUIActions.tsx
+++ b/login-workflow/example/src/actions/AuthUIActions.tsx
@@ -11,7 +11,7 @@ function getRandomInt(max: number): number {
 
 function isRandomFailure(): boolean {
     const randomResponseNumber = getRandomInt(100);
-    return false; // randomResponseNumber < 10;
+    return true; // randomResponseNumber < 10;
 }
 
 type AuthUIActionsWithApp = (appHelper: AppContextType) => AuthUIActions;
@@ -90,7 +90,7 @@ export const ProjectAuthUIActions: AuthUIActionsWithApp = (appHelper) => ({
 
         if (isRandomFailure()) {
             // reject(new Error('LOGIN.GENERIC_ERROR'));
-            throw new Error('LOGIN.INVALID_CREDENTIALS');
+            throw new Error('bluiAuth:LOGIN.INVALID_CREDENTIALS');
         }
 
         LocalStorage.saveAuthCredentials(email, email);

--- a/login-workflow/src/components/Error/ErrorManager.tsx
+++ b/login-workflow/src/components/Error/ErrorManager.tsx
@@ -33,6 +33,7 @@ export type ErrorManagerProps = {
         dismissLabel?: string;
     };
     messageBoxConfig?: {
+        title?: string;
         dismissible?: boolean;
         position?: 'top' | 'bottom';
         fontColor?: string;
@@ -79,7 +80,7 @@ const ErrorManager: React.FC<ErrorManagerProps> = (props): JSX.Element => {
             <BasicDialog
                 open={error.length > 0}
                 title={dialogConfig?.title ?? t('bluiCommon:MESSAGES.ERROR')}
-                body={error}
+                body={t(error)}
                 onClose={onClose}
                 dismissButtonText={dialogConfig?.dismissLabel}
             />
@@ -92,7 +93,8 @@ const ErrorManager: React.FC<ErrorManagerProps> = (props): JSX.Element => {
 
         return (
             <ErrorMessageBox
-                errorMessage={error}
+                title={dialogConfig?.title ?? t('bluiCommon:MESSAGES.ERROR')}
+                errorMessage={t(error)}
                 dismissible={dismissible}
                 sx={sx}
                 backgroundColor={backgroundColor}

--- a/login-workflow/src/components/Error/ErrorMessageBox.tsx
+++ b/login-workflow/src/components/Error/ErrorMessageBox.tsx
@@ -8,6 +8,10 @@ export type ErrorMessageBoxProps = {
     /**
      * The text to show in the title
      */
+    title: string;
+    /**
+     * The text to show in the message
+     */
     errorMessage: string;
 
     /**
@@ -41,7 +45,8 @@ export type ErrorMessageBoxProps = {
 /**
  * Component that renders a basic message box with an error message and a configurable dismiss button.
  *
- * @param errorMessage text to show in the title
+ * @param title text to show in the title
+ * @param errorMessage text to show in the message
  * @param backgroundColor the background color of the message box
  * @param dismissible whether the message box can be dismissed
  * @param fontColor the font color of the text inside the message box
@@ -51,7 +56,7 @@ export type ErrorMessageBoxProps = {
  * @category Component
  */
 const ErrorMessageBox = (props: ErrorMessageBoxProps): JSX.Element => {
-    const { errorMessage, backgroundColor, dismissible = true, fontColor, onClose = (): void => {}, sx } = props;
+    const { title, errorMessage, backgroundColor, dismissible = true, fontColor, onClose = (): void => {}, sx } = props;
 
     return (
         <Box
@@ -81,7 +86,10 @@ const ErrorMessageBox = (props: ErrorMessageBoxProps): JSX.Element => {
                     }}
                 />
             )}
-            <Typography variant="body2">{errorMessage}</Typography>
+            <Box>
+                <Typography>{title}</Typography>
+                <Typography sx={{ fontSize: 'body2' }}>{errorMessage}</Typography>
+            </Box>
         </Box>
     );
 };

--- a/login-workflow/src/components/Error/ErrorMessageBox.tsx
+++ b/login-workflow/src/components/Error/ErrorMessageBox.tsx
@@ -45,7 +45,7 @@ export type ErrorMessageBoxProps = {
 /**
  * Component that renders a basic message box with an error message and a configurable dismiss button.
  *
- * @param title text to show in the title
+ * @param text to show as the title
  * @param errorMessage text to show in the message
  * @param backgroundColor the background color of the message box
  * @param dismissible whether the message box can be dismissed

--- a/login-workflow/src/components/Error/ErrorMessageBox.tsx
+++ b/login-workflow/src/components/Error/ErrorMessageBox.tsx
@@ -88,7 +88,7 @@ const ErrorMessageBox = (props: ErrorMessageBoxProps): JSX.Element => {
             )}
             <Box>
                 <Typography>{title}</Typography>
-                <Typography sx={{ fontSize: 'body2' }}>{errorMessage}</Typography>
+                <Typography variant="body2">{errorMessage}</Typography>
             </Box>
         </Box>
     );

--- a/login-workflow/src/contexts/ErrorContext/useErrorManager.tsx
+++ b/login-workflow/src/contexts/ErrorContext/useErrorManager.tsx
@@ -24,7 +24,6 @@ export const useErrorManager = (): {
         }
         return {
             ...errorConfig,
-            dialogConfig: { title: 'Error' },
             error: err.message,
             onClose: (): void => {
                 setError(new Error());


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->
Fixes BLUI-4933 and BLUI-4942

Fixes https://github.com/etn-ccis/blui-react-workflows/issues/513# https://github.com/etn-ccis/blui-react-workflows/issues/510# https://github.com/etn-ccis/blui-react-workflows/issues/507#.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Update ErrorManager 
 ErrorDialogWithProps to use translations for body
 ErrorMessageBoxWithProps to use translations for errorMessage
- Update ErrorMessageBox to have title

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)
![image](https://github.com/etn-ccis/blui-react-workflows/assets/119693939/ffc5f3f0-174f-4c2d-9448-66cb2aa695ac)
![image](https://github.com/etn-ccis/blui-react-workflows/assets/119693939/00a0d676-ddf8-4df8-a58b-ba8706c27fd5)
![image](https://github.com/etn-ccis/blui-react-workflows/assets/119693939/75d0f5b5-ce1b-467a-b0e2-2db76c2a61db)
![image](https://github.com/etn-ccis/blui-react-workflows/assets/119693939/076e7f89-aa89-4ef1-86a4-99242baf4dba)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- clone and git checkout feature/blui-4933-error-translations
- update line 14 in AuthUIAction to return true;
- yarn start:example
- enter credentials click login
- translation error displays in message-box (use app local storage to toggle languages)
- update example Login screen with mode: ‘dialog’
- enter credentials click login
- translation error displays in dialog (use app local storage to toggle languages)
- uncomment line 89 in AuthUIAction to throw custom error


<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
