### PR TITLE
Add BLCSelfRegistrationSuccessScreen

### DIFF
--- a/login-workflow/example/src/navigation/AppRouter.tsx
+++ b/login-workflow/example/src/navigation/AppRouter.tsx
@@ -9,8 +9,11 @@ import {
     ResetPasswordScreen,
     RegistrationWorkflow,
     CreateNewOrgScreen,
+    CreatePasswordScreen,
     CreateAccountScreen,
+    AccountDetailsScreen,
     EulaScreen,
+    BLCSelfRegistrationSuccessScreen,
 } from '@brightlayer-ui/react-auth-workflow';
 import { useApp } from '../contexts/AppContextProvider';
 import { useNavigate } from 'react-router';
@@ -133,10 +136,13 @@ export const AppRouter: React.FC = () => {
                 <Route
                     path={'/selfregistration'}
                     element={
-                        <RegistrationWorkflow>
+                        <RegistrationWorkflow successScreen={<BLCSelfRegistrationSuccessScreen />}>
                             <EulaScreen />
-                            <CreateNewOrgScreen />
+                            <CreatePasswordScreen />
+                            {/* @TODO: Create account screen will need pulled out for the final selfregistration workflow. Email will need to be handled in the url params?? */}
                             <CreateAccountScreen />
+                            <AccountDetailsScreen />
+                            <CreateNewOrgScreen />
                         </RegistrationWorkflow>
                     }
                 />

--- a/login-workflow/src/screens/BLCSelfRegistrationSuccessScreen/BLCSelfRegistrationSuccessScreen.tsx
+++ b/login-workflow/src/screens/BLCSelfRegistrationSuccessScreen/BLCSelfRegistrationSuccessScreen.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import { Trans, useTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import Typography from '@mui/material/Typography';
-import CheckCircle from '@mui/icons-material/CheckCircle';
 import { SuccessScreenBase, SuccessScreenProps } from '..';
 import { useRegistrationWorkflowContext, useRegistrationContext } from '../../contexts';
 import Box from '@mui/material/Box';
@@ -91,13 +90,11 @@ export const BLCSelfRegistrationSuccessScreen: React.FC<SuccessScreenProps> = (p
     } = props;
 
     const workflowCardHeaderProps = {
-        // title: t('bluiRegistration:REGISTRATION.STEPS.COMPLETE'),
         title: t('Account & Organization Created'),
         ...WorkflowCardHeaderProps,
     };
 
     const workflowCardActionsProps = {
-        // nextLabel: t('bluiCommon:ACTIONS.FINISH'),
         nextLabel: t('Return to Login'),
         showNext: true,
         canGoNext: canDismiss,

--- a/login-workflow/src/screens/BLCSelfRegistrationSuccessScreen/BLCSelfRegistrationSuccessScreen.tsx
+++ b/login-workflow/src/screens/BLCSelfRegistrationSuccessScreen/BLCSelfRegistrationSuccessScreen.tsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { Trans, useTranslation } from 'react-i18next';
+import Typography from '@mui/material/Typography';
+import CheckCircle from '@mui/icons-material/CheckCircle';
+import { SuccessScreenBase, SuccessScreenProps } from '..';
+import { useRegistrationWorkflowContext, useRegistrationContext } from '../../contexts';
+import Box from '@mui/material/Box';
+import { AccountCircle, Business } from '@mui/icons-material';
+
+/**
+ * Component that renders a success screen for when registration completes.
+ *
+ * @param icon the icon to be displayed on the screen
+ * @param messageTitle title of the success message
+ * @param message success message to be displayed on the screen
+ * @param onDismiss function to call when user clicks button
+ * @param canDismiss function to call when the dismiss button is clicked
+ *
+ * @category Component
+ */
+
+const BLCSelfRegistrationSuccessIcons = (): JSX.Element => (
+    <Box sx={{ display: 'flex' }}>
+        <Box
+            sx={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                width: '100px',
+                height: '100px',
+                backgroundColor: '#e0eff8',
+                borderRadius: '50%',
+            }}
+        >
+            <AccountCircle color={'primary'} sx={{ fontSize: 54 }} />
+        </Box>
+        <Box
+            sx={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                width: '100px',
+                height: '100px',
+                backgroundColor: '#e0eff8',
+                borderRadius: '50%',
+                ml: 3,
+            }}
+        >
+            <Business color={'primary'} sx={{ fontSize: 54 }} />
+        </Box>
+    </Box>
+);
+
+export const BLCSelfRegistrationSuccessScreen: React.FC<SuccessScreenProps> = (props) => {
+    const { navigate, routeConfig } = useRegistrationContext();
+    const { t } = useTranslation();
+
+    const {
+        screenData: {
+            AccountDetails: { firstName, lastName },
+            CreateAccount: { emailAddress: email }, // @TODO, get email from the url params or some other location as the CreateAccountScreen wont be part of this workflow at the end.
+            Other: {
+                // @ts-ignore
+                CreateOrganization: { organizationName: organization },
+            },
+        },
+    } = useRegistrationWorkflowContext();
+
+    const {
+        icon = <BLCSelfRegistrationSuccessIcons />,
+        messageTitle = `${t('bluiCommon:MESSAGES.WELCOME')}, ${firstName} ${lastName}!`,
+        message = (
+            <Box sx={{ textAlign: 'left' }}>
+                <Typography variant="subtitle2" sx={{ mt: 2 }}>
+                    Your account has successfully been created with the email <b>{email}</b>.
+                </Typography>
+                <Typography variant="subtitle2" sx={{ mt: 2 }}>
+                    Your Organization<b>{` ${String(organization)}`}</b> has also been successfully created and you are
+                    now the Admin.
+                </Typography>
+                <Typography variant="subtitle2" sx={{ mt: 2 }}>
+                    You can now Login using your email address and password associated with your account.
+                </Typography>
+            </Box>
+        ),
+        onDismiss = (): void => navigate(routeConfig.LOGIN as string),
+        canDismiss = true,
+        WorkflowCardHeaderProps,
+        WorkflowCardActionsProps,
+        ...otherRegistrationSuccessScreenProps
+    } = props;
+
+    const workflowCardHeaderProps = {
+        // title: t('bluiRegistration:REGISTRATION.STEPS.COMPLETE'),
+        title: t('Account & Organization Created'),
+        ...WorkflowCardHeaderProps,
+    };
+
+    const workflowCardActionsProps = {
+        // nextLabel: t('bluiCommon:ACTIONS.FINISH'),
+        nextLabel: t('Return to Login'),
+        showNext: true,
+        canGoNext: canDismiss,
+        fullWidthButton: true,
+        ...WorkflowCardActionsProps,
+        onNext: (): void => {
+            onDismiss();
+            WorkflowCardActionsProps?.onNext?.();
+        },
+    };
+
+    return (
+        <SuccessScreenBase
+            WorkflowCardHeaderProps={workflowCardHeaderProps}
+            WorkflowCardActionsProps={workflowCardActionsProps}
+            icon={icon}
+            messageTitle={messageTitle}
+            message={message}
+            {...otherRegistrationSuccessScreenProps}
+        />
+    );
+};

--- a/login-workflow/src/screens/BLCSelfRegistrationSuccessScreen/index.ts
+++ b/login-workflow/src/screens/BLCSelfRegistrationSuccessScreen/index.ts
@@ -1,0 +1,1 @@
+export * from './BLCSelfRegistrationSuccessScreen';

--- a/login-workflow/src/screens/index.ts
+++ b/login-workflow/src/screens/index.ts
@@ -16,3 +16,4 @@ export * from './ExistingAccountSuccessScreen';
 export * from './SiteOptionsScreen';
 export * from './CreateNewOrgScreen';
 export * from './OrganizationDetailsScreen';
+export * from './BLCSelfRegistrationSuccessScreen';


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes BLUI-4851.

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Add BLCSelfRegistrationSuccessScreen

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

-
![Screenshot 2023-12-15 at 10 26 24 AM](https://github.com/etn-ccis/blui-react-workflows/assets/13989985/81ce0731-a560-42fc-8cb0-151aebd3e3f2)


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- yarn start:example
- navigate to localhost:3000/selfregistration
- go through the workflow, populating data as needed
- complete workflow and observe custom success screen

<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?
notes: There is functionality that will need to go into this once the rest of workflow is complete that cannot be done now. I left `@todo` comments for the things that will need changed and can write a followup story to this one so that it can be tracked. 

I opted to use the design encouraged by our SuccessScreenBase so the title text is centered instead of left aligned and the space about the icons is greater than in the seed-ui Image. 

I also decided to remove the button that was permanently disabled in the seed-ui. We can add the button in the future if/when the additional functionality is implemented.
