### PR TITLE
support partial overried for successscreen slotprops

### DIFF
--- a/login-workflow/src/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
+++ b/login-workflow/src/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
@@ -123,7 +123,6 @@ export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props)
             WorkflowCardActionsProps?.onPrevious?.();
         },
     };
-
     return (
         <ForgotPasswordScreenBase
             WorkflowCardBaseProps={workflowCardBaseProps}
@@ -158,10 +157,13 @@ export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props)
                                 </Trans>
                             </Box>
                         ),
+                        ...slotProps?.SuccessScreen?.EmptyStateProps,
                     },
                     WorkflowCardHeaderProps: {
                         title: t('bluiAuth:HEADER.FORGOT_PASSWORD'),
+                        ...slotProps?.SuccessScreen?.WorkflowCardHeaderProps,
                     },
+                                        ...slotProps.SuccessScreen,
                     WorkflowCardActionsProps: {
                         showNext: true,
                         nextLabel: t('bluiCommon:ACTIONS.DONE'),
@@ -170,8 +172,8 @@ export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props)
                         onNext: (): void => {
                             navigate(routeConfig.LOGIN as string);
                         },
+                        ...slotProps?.SuccessScreen?.WorkflowCardActionsProps,
                     },
-                    ...slotProps.SuccessScreen,
                 },
             }}
             {...otherProps}

--- a/login-workflow/src/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
+++ b/login-workflow/src/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
@@ -137,6 +137,7 @@ export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props)
             slots={slots}
             slotProps={{
                 SuccessScreen: {
+                    ...slotProps.SuccessScreen,
                     EmptyStateProps: {
                         icon: <CheckCircle color={'primary'} sx={{ fontSize: 100, mb: 5 }} />,
                         title: t('bluiCommon:MESSAGES.EMAIL_SENT'),

--- a/login-workflow/src/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
+++ b/login-workflow/src/screens/ForgotPasswordScreen/ForgotPasswordScreen.tsx
@@ -163,7 +163,6 @@ export const ForgotPasswordScreen: React.FC<ForgotPasswordScreenProps> = (props)
                         title: t('bluiAuth:HEADER.FORGOT_PASSWORD'),
                         ...slotProps?.SuccessScreen?.WorkflowCardHeaderProps,
                     },
-                                        ...slotProps.SuccessScreen,
                     WorkflowCardActionsProps: {
                         showNext: true,
                         nextLabel: t('bluiCommon:ACTIONS.DONE'),


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes # . BLUI - 6688

<!-- Include a bulleted list summarizing the main changes you have made in this PR -->

#### Changes proposed in this Pull Request:

- Updated code to support partial override for successscreen slotprops
-
-

<!-- Include screenshots if they will help illustrate the changes in this PR -->

#### Screenshots / Screen Recording (if applicable)

- 
<img width="830" alt="Screenshot 2025-05-09 at 2 19 11 PM" src="https://github.com/user-attachments/assets/71904a89-3e24-43b9-bec0-2930ace879cc" />


<!-- Instruction for PR reviewers, if more complicated than a simple yarn start -->

#### To Test:

- In MainRouter.tsx send slotProps with custom values to ForgotPasswordScreen

`slotProps={{
                                    SuccessScreen: {
                                        WorkflowCardActionsProps: {
                                            onNext: (): void => {
                                                // eslint-disable-next-line no-console
                                                console.log('SuccessScreen onNext custom');
                                                // eslint-disable-next-line no-alert
                                                alert('SuccessScreen onNext custom');
                                            },
                                        },
                                        WorkflowCardHeaderProps: {
                                            title: 'Forgot Password Custom',
                                        },
                                        EmptyStateProps: {
                                            icon: <CheckCircle color={'primary'} sx={{ fontSize: 100, mb: 5 }} />,
                                            title: 'Email Sent custom title',
                                            description: 'A link to reset your password is sent. Custom Description',
                                        },
                                    },
                                }}
`
<!-- Useful for draft pull requests -->

#### Any specific feedback you are looking for?

-
